### PR TITLE
Unify restate.Service and restate.Object into restate.Reflect

### DIFF
--- a/examples/codegen/proto/helloworld_restate.pb.go
+++ b/examples/codegen/proto/helloworld_restate.pb.go
@@ -62,7 +62,7 @@ type UnsafeGreeterServer interface {
 	mustEmbedUnimplementedGreeterServer()
 }
 
-func NewGreeterServer(srv GreeterServer, opts ...sdk_go.ServiceOption) sdk_go.ServiceDefinition {
+func NewGreeterServer(srv GreeterServer, opts ...sdk_go.ServiceDefinitionOption) sdk_go.ServiceDefinition {
 	// If the following call panics, it indicates UnimplementedGreeterServer was
 	// embedded by pointer and is nil.  This will cause panics if an
 	// unimplemented method is ever invoked, so we test this at initialization
@@ -70,7 +70,7 @@ func NewGreeterServer(srv GreeterServer, opts ...sdk_go.ServiceOption) sdk_go.Se
 	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
 		t.testEmbeddedByValue()
 	}
-	sOpts := append([]sdk_go.ServiceOption{sdk_go.WithProtoJSON}, opts...)
+	sOpts := append([]sdk_go.ServiceDefinitionOption{sdk_go.WithProtoJSON}, opts...)
 	router := sdk_go.NewService("Greeter", sOpts...)
 	router = router.Handler("SayHello", sdk_go.NewServiceHandler(srv.SayHello))
 	return router
@@ -176,7 +176,7 @@ type UnsafeCounterServer interface {
 	mustEmbedUnimplementedCounterServer()
 }
 
-func NewCounterServer(srv CounterServer, opts ...sdk_go.ObjectOption) sdk_go.ServiceDefinition {
+func NewCounterServer(srv CounterServer, opts ...sdk_go.ServiceDefinitionOption) sdk_go.ServiceDefinition {
 	// If the following call panics, it indicates UnimplementedCounterServer was
 	// embedded by pointer and is nil.  This will cause panics if an
 	// unimplemented method is ever invoked, so we test this at initialization
@@ -184,7 +184,7 @@ func NewCounterServer(srv CounterServer, opts ...sdk_go.ObjectOption) sdk_go.Ser
 	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
 		t.testEmbeddedByValue()
 	}
-	sOpts := append([]sdk_go.ObjectOption{sdk_go.WithProtoJSON}, opts...)
+	sOpts := append([]sdk_go.ServiceDefinitionOption{sdk_go.WithProtoJSON}, opts...)
 	router := sdk_go.NewObject("Counter", sOpts...)
 	router = router.Handler("Add", sdk_go.NewObjectHandler(srv.Add))
 	router = router.Handler("Get", sdk_go.NewObjectSharedHandler(srv.Get))

--- a/examples/ticketreservation/main.go
+++ b/examples/ticketreservation/main.go
@@ -12,9 +12,9 @@ import (
 func main() {
 	server := server.NewRestate().
 		// Handlers can be inferred from object methods
-		Bind(restate.Object(&userSession{})).
-		Bind(restate.Object(&ticketService{})).
-		Bind(restate.Service(&checkout{}))
+		Bind(restate.Reflect(&userSession{})).
+		Bind(restate.Reflect(&ticketService{})).
+		Bind(restate.Reflect(&checkout{}))
 
 	if err := server.Start(context.Background(), ":9080"); err != nil {
 		slog.Error("application exited unexpectedly", "err", err.Error())

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -51,34 +51,18 @@ type RunOption interface {
 	BeforeRun(*RunOptions)
 }
 
-type ServiceHandlerOptions struct {
+type HandlerOptions struct {
 	Codec encoding.PayloadCodec
 }
 
-type ServiceHandlerOption interface {
-	BeforeServiceHandler(*ServiceHandlerOptions)
+type HandlerOption interface {
+	BeforeHandler(*HandlerOptions)
 }
 
-type ObjectHandlerOptions struct {
-	Codec encoding.PayloadCodec
-}
-
-type ObjectHandlerOption interface {
-	BeforeObjectHandler(*ObjectHandlerOptions)
-}
-
-type ServiceOptions struct {
+type ServiceDefinitionOptions struct {
 	DefaultCodec encoding.PayloadCodec
 }
 
-type ServiceOption interface {
-	BeforeService(*ServiceOptions)
-}
-
-type ObjectOptions struct {
-	DefaultCodec encoding.PayloadCodec
-}
-
-type ObjectOption interface {
-	BeforeObject(*ObjectOptions)
+type ServiceDefinitionOption interface {
+	BeforeServiceDefinition(*ServiceDefinitionOptions)
 }

--- a/options.go
+++ b/options.go
@@ -7,8 +7,7 @@ import (
 
 // re-export for use in generated code
 type CallOption = options.CallOption
-type ServiceOption = options.ServiceOption
-type ObjectOption = options.ObjectOption
+type ServiceDefinitionOption = options.ServiceDefinitionOption
 
 type withCodec struct {
 	codec encoding.Codec
@@ -43,21 +42,13 @@ type withPayloadCodec struct {
 	codec encoding.PayloadCodec
 }
 
-var _ options.ServiceHandlerOption = withPayloadCodec{}
-var _ options.ServiceOption = withPayloadCodec{}
-var _ options.ObjectHandlerOption = withPayloadCodec{}
-var _ options.ObjectOption = withPayloadCodec{}
+var _ options.HandlerOption = withPayloadCodec{}
+var _ options.ServiceDefinitionOption = withPayloadCodec{}
 
-func (w withPayloadCodec) BeforeServiceHandler(opts *options.ServiceHandlerOptions) {
+func (w withPayloadCodec) BeforeHandler(opts *options.HandlerOptions) {
 	opts.Codec = w.codec
 }
-func (w withPayloadCodec) BeforeObjectHandler(opts *options.ObjectHandlerOptions) {
-	opts.Codec = w.codec
-}
-func (w withPayloadCodec) BeforeService(opts *options.ServiceOptions) {
-	opts.DefaultCodec = w.codec
-}
-func (w withPayloadCodec) BeforeObject(opts *options.ObjectOptions) {
+func (w withPayloadCodec) BeforeServiceDefinition(opts *options.ServiceDefinitionOptions) {
 	opts.DefaultCodec = w.codec
 }
 

--- a/reflect.go
+++ b/reflect.go
@@ -22,25 +22,28 @@ var (
 	typeOfError               = reflect.TypeOf((*error)(nil)).Elem()
 )
 
-// Object converts a struct with methods into a Virtual Object where each correctly-typed
-// and exported method of the struct will become a handler on the Object. The Object name
+// Reflect converts a struct with methods into a service definition where each correctly-typed
+// and exported method of the struct will become a handler in the definition. The service name
 // defaults to the name of the struct, but this can be overidden by providing a `ServiceName() string` method.
-// The handler name is the name of the method. Handler methods should be of the type `ObjectHandlerFn[I, O]` or `ObjectSharedHandlerFn[I, O]`.
+// The handler name is the name of the method. Handler methods should be of the type `ServiceHandlerFn[I,O]`,
+// `ObjectHandlerFn[I, O]` or `ObjectSharedHandlerFn[I, O]`. This function will panic if a mixture of
+// object and service method signatures or opts are provided.
 //
 // Input types will be deserialised with the provided codec (defaults to JSON) except when they are restate.Void,
 // in which case no input bytes or content type may be sent.
 // Output types will be serialised with the provided codec (defaults to JSON) except when they are restate.Void,
 // in which case no data will be sent and no content type set.
-func Object(object any, opts ...options.ObjectOption) *object {
-	typ := reflect.TypeOf(object)
-	val := reflect.ValueOf(object)
+func Reflect(rcvr any, opts ...options.ServiceDefinitionOption) ServiceDefinition {
+	typ := reflect.TypeOf(rcvr)
+	val := reflect.ValueOf(rcvr)
 	var name string
-	if sn, ok := object.(serviceNamer); ok {
+	if sn, ok := rcvr.(serviceNamer); ok {
 		name = sn.ServiceName()
 	} else {
 		name = reflect.Indirect(val).Type().Name()
 	}
-	definition := NewObject(name, opts...)
+
+	var definition ServiceDefinition
 
 	for m := 0; m < typ.NumMethod(); m++ {
 		method := typ.Method(m)
@@ -50,7 +53,7 @@ func Object(object any, opts ...options.ObjectOption) *object {
 		if !method.IsExported() {
 			continue
 		}
-		// Method needs three ins: receiver, ObjectContext, I
+		// Method needs three ins: receiver, Context, I
 		if mtype.NumIn() != 3 {
 			continue
 		}
@@ -58,12 +61,28 @@ func Object(object any, opts ...options.ObjectOption) *object {
 		var handlerType internal.ServiceHandlerType
 
 		switch mtype.In(1) {
+		case typeOfContext:
+			if definition == nil {
+				definition = NewService(name, opts...)
+			} else if definition.Type() != internal.ServiceType_SERVICE {
+				panic("found a mix of service context arguments and other context arguments")
+			}
 		case typeOfObjectContext:
+			if definition == nil {
+				definition = NewObject(name, opts...)
+			} else if definition.Type() != internal.ServiceType_VIRTUAL_OBJECT {
+				panic("found a mix of object context arguments and other context arguments")
+			}
 			handlerType = internal.ServiceHandlerType_EXCLUSIVE
 		case typeOfSharedObjectContext:
+			if definition == nil {
+				definition = NewObject(name, opts...)
+			} else if definition.Type() != internal.ServiceType_VIRTUAL_OBJECT {
+				panic("found a mix of object context arguments and other context arguments")
+			}
 			handlerType = internal.ServiceHandlerType_SHARED
 		default:
-			// first parameter is not an object context
+			// first parameter is not a context
 			continue
 		}
 
@@ -80,99 +99,65 @@ func Object(object any, opts ...options.ObjectOption) *object {
 		input := mtype.In(2)
 		output := mtype.Out(0)
 
-		definition.Handler(mname, &objectReflectHandler{
-			options.ObjectHandlerOptions{},
-			handlerType,
-			reflectHandler{
-				fn:       method.Func,
-				receiver: val,
-				input:    input,
-				output:   output,
-			},
-		})
+		switch def := definition.(type) {
+		case *service:
+			def.Handler(mname, &serviceReflectHandler{
+				reflectHandler{
+					fn:          method.Func,
+					receiver:    val,
+					input:       input,
+					output:      output,
+					options:     options.HandlerOptions{},
+					handlerType: nil,
+				},
+			})
+		case *object:
+			def.Handler(mname, &objectReflectHandler{
+				reflectHandler{
+					fn:          method.Func,
+					receiver:    val,
+					input:       input,
+					output:      input,
+					options:     options.HandlerOptions{},
+					handlerType: &handlerType,
+				},
+			})
+		}
 	}
 
-	return definition
-}
-
-// Service converts a struct with methods into a Restate Service where each correctly-typed
-// and exported method of the struct will become a handler on the Service. The Service name defaults
-// to the name of the struct, but this can be overidden by providing a `ServiceName() string` method.
-// The handler name is the name of the method. Handler methods should be of the type `ServiceHandlerFn[I, O]`.
-//
-// Input types will be deserialised with the provided codec (defaults to JSON) except when they are restate.Void,
-// in which case no input bytes or content type may be sent.
-// Output types will be serialised with the provided codec (defaults to JSON) except when they are restate.Void,
-// in which case no data will be sent and no content type set.
-func Service(service any, opts ...options.ServiceOption) *service {
-	typ := reflect.TypeOf(service)
-	val := reflect.ValueOf(service)
-	var name string
-	if sn, ok := service.(serviceNamer); ok {
-		name = sn.ServiceName()
-	} else {
-		name = reflect.Indirect(val).Type().Name()
-	}
-	definition := NewService(name, opts...)
-
-	for m := 0; m < typ.NumMethod(); m++ {
-		method := typ.Method(m)
-
-		mtype := method.Type
-		mname := method.Name
-		// Method must be exported.
-		if !method.IsExported() {
-			continue
-		}
-
-		// Method needs three ins: receiver, Context, I
-		if mtype.NumIn() != 3 {
-			continue
-		}
-
-		if ctxType := mtype.In(1); ctxType != typeOfContext {
-			continue
-		}
-
-		// Method needs two outs: O, and error
-		if mtype.NumOut() != 2 {
-			continue
-		}
-
-		// The second return type of the method must be error.
-		if returnType := mtype.Out(1); returnType != typeOfError {
-			continue
-		}
-
-		input := mtype.In(2)
-		output := mtype.Out(0)
-
-		definition.Handler(mname, &serviceReflectHandler{
-			options.ServiceHandlerOptions{},
-			reflectHandler{
-				fn:       method.Func,
-				receiver: val,
-				input:    input,
-				output:   output,
-			},
-		})
+	if definition == nil {
+		panic("no valid handlers could be found within the exported methods on this struct")
 	}
 
 	return definition
 }
 
 type reflectHandler struct {
-	fn       reflect.Value
-	receiver reflect.Value
-	input    reflect.Type
-	output   reflect.Type
+	fn          reflect.Value
+	receiver    reflect.Value
+	input       reflect.Type
+	output      reflect.Type
+	options     options.HandlerOptions
+	handlerType *internal.ServiceHandlerType
 }
 
-func (h *reflectHandler) sealed() {}
+func (h *reflectHandler) getOptions() *options.HandlerOptions {
+	return &h.options
+}
+
+func (h *reflectHandler) InputPayload() *encoding.InputPayload {
+	return encoding.InputPayloadFor(h.options.Codec, reflect.Zero(h.input).Interface())
+}
+
+func (h *reflectHandler) OutputPayload() *encoding.OutputPayload {
+	return encoding.OutputPayloadFor(h.options.Codec, reflect.Zero(h.output).Interface())
+}
+
+func (h *reflectHandler) HandlerType() *internal.ServiceHandlerType {
+	return h.handlerType
+}
 
 type objectReflectHandler struct {
-	options     options.ObjectHandlerOptions
-	handlerType internal.ServiceHandlerType
 	reflectHandler
 }
 
@@ -206,24 +191,7 @@ func (h *objectReflectHandler) Call(ctx ObjectContext, bytes []byte) ([]byte, er
 	return bytes, nil
 }
 
-func (h *objectReflectHandler) getOptions() *options.ObjectHandlerOptions {
-	return &h.options
-}
-
-func (h *objectReflectHandler) InputPayload() *encoding.InputPayload {
-	return encoding.InputPayloadFor(h.options.Codec, reflect.Zero(h.input).Interface())
-}
-
-func (h *objectReflectHandler) OutputPayload() *encoding.OutputPayload {
-	return encoding.OutputPayloadFor(h.options.Codec, reflect.Zero(h.output).Interface())
-}
-
-func (h *objectReflectHandler) HandlerType() *internal.ServiceHandlerType {
-	return &h.handlerType
-}
-
 type serviceReflectHandler struct {
-	options options.ServiceHandlerOptions
 	reflectHandler
 }
 
@@ -255,20 +223,4 @@ func (h *serviceReflectHandler) Call(ctx Context, bytes []byte) ([]byte, error) 
 	}
 
 	return bytes, nil
-}
-
-func (h *serviceReflectHandler) getOptions() *options.ServiceHandlerOptions {
-	return &h.options
-}
-
-func (h *serviceReflectHandler) InputPayload() *encoding.InputPayload {
-	return h.options.Codec.InputPayload(reflect.Zero(h.input))
-}
-
-func (h *serviceReflectHandler) OutputPayload() *encoding.OutputPayload {
-	return h.options.Codec.OutputPayload(reflect.Zero(h.output))
-}
-
-func (h *serviceReflectHandler) HandlerType() *internal.ServiceHandlerType {
-	return nil
 }

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -1,0 +1,127 @@
+package restate_test
+
+import (
+	"context"
+	"testing"
+
+	restate "github.com/restatedev/sdk-go"
+	"github.com/restatedev/sdk-go/internal"
+	"github.com/stretchr/testify/require"
+)
+
+type reflectTestParams struct {
+	rcvr            interface{}
+	opts            []restate.ServiceDefinitionOption
+	serviceName     string
+	serviceType     internal.ServiceType
+	expectedMethods expectedMethods
+	shouldPanic     bool
+}
+
+type expectedMethods = map[string]*internal.ServiceHandlerType
+
+var exclusive = internal.ServiceHandlerType_EXCLUSIVE
+var shared = internal.ServiceHandlerType_SHARED
+
+var tests []reflectTestParams = []reflectTestParams{
+	{rcvr: validObject{}, serviceName: "validObject", expectedMethods: expectedMethods{
+		"Greet":       &exclusive,
+		"GreetShared": &shared,
+	}},
+	{rcvr: validService{}, serviceName: "validService", expectedMethods: expectedMethods{
+		"Greet": nil,
+	}},
+	{rcvr: namedService{}, serviceName: "foobar", expectedMethods: expectedMethods{
+		"Greet": nil,
+	}},
+	{rcvr: mixed{}, shouldPanic: true},
+	{rcvr: empty{}, shouldPanic: true},
+}
+
+func TestReflect(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.serviceName, func(t *testing.T) {
+			defer func() {
+				if err := recover(); err != nil {
+					if test.shouldPanic {
+						return
+					} else {
+						panic(err)
+					}
+				} else if test.shouldPanic {
+					t.Fatal("test should have panicked")
+				}
+			}()
+			def := restate.Reflect(test.rcvr, test.opts...)
+			foundMethods := make([]string, 0, len(def.Handlers()))
+			for k := range def.Handlers() {
+				foundMethods = append(foundMethods, k)
+			}
+			for k, expectedTyp := range test.expectedMethods {
+				handler, ok := def.Handlers()[k]
+				if !ok {
+					t.Fatalf("missing handler %s", k)
+				}
+				require.Equal(t, expectedTyp, handler.HandlerType(), "mismatched handler type")
+			}
+			require.Equal(t, test.serviceName, def.Name())
+		})
+	}
+}
+
+type validObject struct{}
+
+func (validObject) Greet(ctx restate.ObjectContext, _ string) (string, error) {
+	return "", nil
+}
+
+func (validObject) GreetShared(ctx restate.ObjectSharedContext, _ string) (string, error) {
+	return "", nil
+}
+
+func (validObject) SkipInvalidArgCount(ctx restate.ObjectContext) (string, error) {
+	return "", nil
+}
+
+func (validObject) SkipInvalidCtx(ctx context.Context, _ string) (string, error) {
+	return "", nil
+}
+
+func (validObject) SkipInvalidError(ctx restate.ObjectContext, _ string) (string, string) {
+	return "", ""
+}
+
+func (validObject) SkipInvalidRetCount(ctx restate.ObjectContext, _ string) string {
+	return ""
+}
+
+func (validObject) skipUnexported(_ string) (string, error) {
+	return "", nil
+}
+
+type validService struct{}
+
+func (validService) Greet(ctx restate.Context, _ string) (string, error) {
+	return "", nil
+}
+
+type namedService struct{}
+
+func (namedService) ServiceName() string {
+	return "foobar"
+}
+
+func (namedService) Greet(ctx restate.Context, _ string) (string, error) {
+	return "", nil
+}
+
+type mixed struct{}
+
+func (mixed) Greet(ctx restate.Context, _ string) (string, error) {
+	return "", nil
+}
+func (mixed) GreetShared(ctx restate.ObjectSharedContext, _ string) (string, error) {
+	return "", nil
+}
+
+type empty struct{}


### PR DESCRIPTION
These names pollute the namespace a bit and they have similar signatures anyway. Reflect is more descriptive of what they do.