### PR TITLE
Move headers and delays into requestoption/ send option

### DIFF
--- a/context.go
+++ b/context.go
@@ -28,11 +28,11 @@ type Context interface {
 
 	// Service gets a Service accessor by service and method name
 	// Note: use the CallAs helper function to deserialise return values
-	Service(service, method string, opts ...options.CallOption) CallClient
+	Service(service, method string, opts ...options.ClientOption) CallClient
 
 	// Object gets a Object accessor by name, key and method name
 	// Note: use the CallAs helper function to receive serialised values
-	Object(object, key, method string, opts ...options.CallOption) CallClient
+	Object(object, key, method string, opts ...options.ClientOption) CallClient
 
 	// Run runs the function (fn), storing final results (including terminal errors)
 	// durably in the journal, or otherwise for transient errors stopping execution

--- a/context.go
+++ b/context.go
@@ -81,11 +81,11 @@ type Awakeable interface {
 // CallClient represents all the different ways you can invoke a particular service/key/method tuple.
 type CallClient interface {
 	// RequestFuture makes a call and returns a handle on a future response
-	RequestFuture(input any) ResponseFuture
+	RequestFuture(input any, opts ...options.RequestOption) ResponseFuture
 	// Request makes a call and blocks on getting the response which is stored in output
-	Request(input any, output any) error
+	Request(input any, output any, opts ...options.RequestOption) error
 	// Send makes a one-way call which is executed in the background
-	Send(input any, delay time.Duration)
+	Send(input any, opts ...options.SendOption)
 }
 
 // ResponseFuture is a handle on a potentially not-yet completed outbound call.

--- a/examples/codegen/buf.gen.yaml
+++ b/examples/codegen/buf.gen.yaml
@@ -5,12 +5,7 @@ plugins:
   - remote: buf.build/protocolbuffers/go:v1.34.2
     out: .
     opt: paths=source_relative
-  - local:
-      - docker
-      - run
-      - --pull=always
-      - -i
-      - ghcr.io/restatedev/protoc-gen-go-restate:latest
+  - local: protoc-gen-go-restate
     out: .
     opt: paths=source_relative
 inputs:

--- a/examples/codegen/proto/helloworld_restate.pb.go
+++ b/examples/codegen/proto/helloworld_restate.pb.go
@@ -13,25 +13,25 @@ import (
 
 // GreeterClient is the client API for Greeter service.
 type GreeterClient interface {
-	SayHello(opts ...sdk_go.CallOption) sdk_go.TypedCallClient[*HelloRequest, *HelloResponse]
+	SayHello(opts ...sdk_go.ClientOption) sdk_go.TypedCallClient[*HelloRequest, *HelloResponse]
 }
 
 type greeterClient struct {
 	ctx     sdk_go.Context
-	options []sdk_go.CallOption
+	options []sdk_go.ClientOption
 }
 
-func NewGreeterClient(ctx sdk_go.Context, opts ...sdk_go.CallOption) GreeterClient {
-	cOpts := append([]sdk_go.CallOption{sdk_go.WithProtoJSON}, opts...)
+func NewGreeterClient(ctx sdk_go.Context, opts ...sdk_go.ClientOption) GreeterClient {
+	cOpts := append([]sdk_go.ClientOption{sdk_go.WithProtoJSON}, opts...)
 	return &greeterClient{
 		ctx,
 		cOpts,
 	}
 }
-func (c *greeterClient) SayHello(opts ...sdk_go.CallOption) sdk_go.TypedCallClient[*HelloRequest, *HelloResponse] {
+func (c *greeterClient) SayHello(opts ...sdk_go.ClientOption) sdk_go.TypedCallClient[*HelloRequest, *HelloResponse] {
 	cOpts := c.options
 	if len(opts) > 0 {
-		cOpts = append(append([]sdk_go.CallOption{}, cOpts...), opts...)
+		cOpts = append(append([]sdk_go.ClientOption{}, cOpts...), opts...)
 	}
 	return sdk_go.NewTypedCallClient[*HelloRequest, *HelloResponse](c.ctx.Service("Greeter", "SayHello", cOpts...))
 }
@@ -79,57 +79,57 @@ func NewGreeterServer(srv GreeterServer, opts ...sdk_go.ServiceDefinitionOption)
 // CounterClient is the client API for Counter service.
 type CounterClient interface {
 	// Mutate the value
-	Add(opts ...sdk_go.CallOption) sdk_go.TypedCallClient[*AddRequest, *GetResponse]
+	Add(opts ...sdk_go.ClientOption) sdk_go.TypedCallClient[*AddRequest, *GetResponse]
 	// Get the current value
-	Get(opts ...sdk_go.CallOption) sdk_go.TypedCallClient[*GetRequest, *GetResponse]
+	Get(opts ...sdk_go.ClientOption) sdk_go.TypedCallClient[*GetRequest, *GetResponse]
 	// Internal method to store an awakeable ID for the Watch method
-	AddWatcher(opts ...sdk_go.CallOption) sdk_go.TypedCallClient[*AddWatcherRequest, *AddWatcherResponse]
+	AddWatcher(opts ...sdk_go.ClientOption) sdk_go.TypedCallClient[*AddWatcherRequest, *AddWatcherResponse]
 	// Wait for the counter to change and then return the new value
-	Watch(opts ...sdk_go.CallOption) sdk_go.TypedCallClient[*WatchRequest, *GetResponse]
+	Watch(opts ...sdk_go.ClientOption) sdk_go.TypedCallClient[*WatchRequest, *GetResponse]
 }
 
 type counterClient struct {
 	ctx     sdk_go.Context
 	key     string
-	options []sdk_go.CallOption
+	options []sdk_go.ClientOption
 }
 
-func NewCounterClient(ctx sdk_go.Context, key string, opts ...sdk_go.CallOption) CounterClient {
-	cOpts := append([]sdk_go.CallOption{sdk_go.WithProtoJSON}, opts...)
+func NewCounterClient(ctx sdk_go.Context, key string, opts ...sdk_go.ClientOption) CounterClient {
+	cOpts := append([]sdk_go.ClientOption{sdk_go.WithProtoJSON}, opts...)
 	return &counterClient{
 		ctx,
 		key,
 		cOpts,
 	}
 }
-func (c *counterClient) Add(opts ...sdk_go.CallOption) sdk_go.TypedCallClient[*AddRequest, *GetResponse] {
+func (c *counterClient) Add(opts ...sdk_go.ClientOption) sdk_go.TypedCallClient[*AddRequest, *GetResponse] {
 	cOpts := c.options
 	if len(opts) > 0 {
-		cOpts = append(append([]sdk_go.CallOption{}, cOpts...), opts...)
+		cOpts = append(append([]sdk_go.ClientOption{}, cOpts...), opts...)
 	}
 	return sdk_go.NewTypedCallClient[*AddRequest, *GetResponse](c.ctx.Object("Counter", c.key, "Add", cOpts...))
 }
 
-func (c *counterClient) Get(opts ...sdk_go.CallOption) sdk_go.TypedCallClient[*GetRequest, *GetResponse] {
+func (c *counterClient) Get(opts ...sdk_go.ClientOption) sdk_go.TypedCallClient[*GetRequest, *GetResponse] {
 	cOpts := c.options
 	if len(opts) > 0 {
-		cOpts = append(append([]sdk_go.CallOption{}, cOpts...), opts...)
+		cOpts = append(append([]sdk_go.ClientOption{}, cOpts...), opts...)
 	}
 	return sdk_go.NewTypedCallClient[*GetRequest, *GetResponse](c.ctx.Object("Counter", c.key, "Get", cOpts...))
 }
 
-func (c *counterClient) AddWatcher(opts ...sdk_go.CallOption) sdk_go.TypedCallClient[*AddWatcherRequest, *AddWatcherResponse] {
+func (c *counterClient) AddWatcher(opts ...sdk_go.ClientOption) sdk_go.TypedCallClient[*AddWatcherRequest, *AddWatcherResponse] {
 	cOpts := c.options
 	if len(opts) > 0 {
-		cOpts = append(append([]sdk_go.CallOption{}, cOpts...), opts...)
+		cOpts = append(append([]sdk_go.ClientOption{}, cOpts...), opts...)
 	}
 	return sdk_go.NewTypedCallClient[*AddWatcherRequest, *AddWatcherResponse](c.ctx.Object("Counter", c.key, "AddWatcher", cOpts...))
 }
 
-func (c *counterClient) Watch(opts ...sdk_go.CallOption) sdk_go.TypedCallClient[*WatchRequest, *GetResponse] {
+func (c *counterClient) Watch(opts ...sdk_go.ClientOption) sdk_go.TypedCallClient[*WatchRequest, *GetResponse] {
 	cOpts := c.options
 	if len(opts) > 0 {
-		cOpts = append(append([]sdk_go.CallOption{}, cOpts...), opts...)
+		cOpts = append(append([]sdk_go.ClientOption{}, cOpts...), opts...)
 	}
 	return sdk_go.NewTypedCallClient[*WatchRequest, *GetResponse](c.ctx.Object("Counter", c.key, "Watch", cOpts...))
 }

--- a/facilitators.go
+++ b/facilitators.go
@@ -2,7 +2,6 @@ package restate
 
 import (
 	"errors"
-	"time"
 
 	"github.com/restatedev/sdk-go/internal/options"
 )
@@ -58,11 +57,11 @@ func AwakeableAs[T any](ctx Context, options ...options.AwakeableOption) TypedAw
 // TypedCallClient is an extension of [CallClient] which deals in typed values
 type TypedCallClient[I any, O any] interface {
 	// RequestFuture makes a call and returns a handle on a future response
-	RequestFuture(input I) TypedResponseFuture[O]
+	RequestFuture(input I, opts ...options.RequestOption) TypedResponseFuture[O]
 	// Request makes a call and blocks on getting the response
-	Request(input I) (O, error)
+	Request(input I, opts ...options.RequestOption) (O, error)
 	// Send makes a one-way call which is executed in the background
-	Send(input I, delay time.Duration)
+	Send(input I, opts ...options.SendOption)
 }
 
 type typedCallClient[I any, O any] struct {
@@ -76,17 +75,17 @@ func NewTypedCallClient[I any, O any](client CallClient) TypedCallClient[I, O] {
 	return typedCallClient[I, O]{client}
 }
 
-func (t typedCallClient[I, O]) Request(input I) (output O, err error) {
-	err = t.inner.RequestFuture(input).Response(&output)
+func (t typedCallClient[I, O]) Request(input I, opts ...options.RequestOption) (output O, err error) {
+	err = t.inner.RequestFuture(input, opts...).Response(&output)
 	return
 }
 
-func (t typedCallClient[I, O]) RequestFuture(input I) TypedResponseFuture[O] {
-	return typedResponseFuture[O]{t.inner.RequestFuture(input)}
+func (t typedCallClient[I, O]) RequestFuture(input I, opts ...options.RequestOption) TypedResponseFuture[O] {
+	return typedResponseFuture[O]{t.inner.RequestFuture(input, opts...)}
 }
 
-func (t typedCallClient[I, O]) Send(input I, delay time.Duration) {
-	t.inner.Send(input, delay)
+func (t typedCallClient[I, O]) Send(input I, opts ...options.SendOption) {
+	t.inner.Send(input, opts...)
 }
 
 // TypedResponseFuture is an extension of [ResponseFuture] which returns typed responses instead of accepting a pointer

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -1,6 +1,10 @@
 package options
 
-import "github.com/restatedev/sdk-go/encoding"
+import (
+	"time"
+
+	"github.com/restatedev/sdk-go/encoding"
+)
 
 type AwakeableOptions struct {
 	Codec encoding.Codec
@@ -35,12 +39,28 @@ type SetOption interface {
 }
 
 type CallOptions struct {
-	Codec   encoding.Codec
-	Headers map[string]string
+	Codec encoding.Codec
 }
 
 type CallOption interface {
 	BeforeCall(*CallOptions)
+}
+
+type RequestOptions struct {
+	Headers map[string]string
+}
+
+type RequestOption interface {
+	BeforeRequest(*RequestOptions)
+}
+
+type SendOptions struct {
+	Headers map[string]string
+	Delay   time.Duration
+}
+
+type SendOption interface {
+	BeforeSend(*SendOptions)
 }
 
 type RunOptions struct {

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -38,12 +38,12 @@ type SetOption interface {
 	BeforeSet(*SetOptions)
 }
 
-type CallOptions struct {
+type ClientOptions struct {
 	Codec encoding.Codec
 }
 
-type CallOption interface {
-	BeforeCall(*CallOptions)
+type ClientOption interface {
+	BeforeClient(*ClientOptions)
 }
 
 type RequestOptions struct {

--- a/internal/state/call.go
+++ b/internal/state/call.go
@@ -24,13 +24,18 @@ type serviceCall struct {
 }
 
 // RequestFuture makes a call and returns a handle on the response
-func (c *serviceCall) RequestFuture(input any) restate.ResponseFuture {
+func (c *serviceCall) RequestFuture(input any, opts ...options.RequestOption) restate.ResponseFuture {
+	o := options.RequestOptions{}
+	for _, opt := range opts {
+		opt.BeforeRequest(&o)
+	}
+
 	bytes, err := encoding.Marshal(c.options.Codec, input)
 	if err != nil {
 		panic(c.machine.newCodecFailure(fmt.Errorf("failed to marshal RequestFuture input: %w", err)))
 	}
 
-	entry, entryIndex := c.machine.doCall(c.service, c.key, c.method, c.options.Headers, bytes)
+	entry, entryIndex := c.machine.doCall(c.service, c.key, c.method, o.Headers, bytes)
 
 	return decodingResponseFuture{
 		futures.NewResponseFuture(c.machine.suspensionCtx, entry, entryIndex, func(err error) any { return c.machine.newProtocolViolation(entry, err) }),
@@ -59,17 +64,22 @@ func (d decodingResponseFuture) Response(output any) (err error) {
 }
 
 // Request makes a call and blocks on the response
-func (c *serviceCall) Request(input any, output any) error {
-	return c.RequestFuture(input).Response(output)
+func (c *serviceCall) Request(input any, output any, opts ...options.RequestOption) error {
+	return c.RequestFuture(input, opts...).Response(output)
 }
 
 // Send runs a call in the background after delay duration
-func (c *serviceCall) Send(input any, delay time.Duration) {
+func (c *serviceCall) Send(input any, opts ...options.SendOption) {
+	o := options.SendOptions{}
+	for _, opt := range opts {
+		opt.BeforeSend(&o)
+	}
+
 	bytes, err := encoding.Marshal(c.options.Codec, input)
 	if err != nil {
 		panic(c.machine.newCodecFailure(fmt.Errorf("failed to marshal Send input: %w", err)))
 	}
-	c.machine.sendCall(c.service, c.key, c.method, c.options.Headers, bytes, delay)
+	c.machine.sendCall(c.service, c.key, c.method, o.Headers, bytes, o.Delay)
 	return
 }
 

--- a/internal/state/call.go
+++ b/internal/state/call.go
@@ -16,7 +16,7 @@ import (
 )
 
 type serviceCall struct {
-	options options.CallOptions
+	options options.ClientOptions
 	machine *Machine
 	service string
 	key     string
@@ -47,7 +47,7 @@ func (c *serviceCall) RequestFuture(input any, opts ...options.RequestOption) re
 type decodingResponseFuture struct {
 	*futures.ResponseFuture
 	machine *Machine
-	options options.CallOptions
+	options options.ClientOptions
 }
 
 func (d decodingResponseFuture) Response(output any) (err error) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -117,10 +117,10 @@ func (c *Context) After(d time.Duration) restate.After {
 	return c.machine.after(d)
 }
 
-func (c *Context) Service(service, method string, opts ...options.CallOption) restate.CallClient {
-	o := options.CallOptions{}
+func (c *Context) Service(service, method string, opts ...options.ClientOption) restate.CallClient {
+	o := options.ClientOptions{}
 	for _, opt := range opts {
-		opt.BeforeCall(&o)
+		opt.BeforeClient(&o)
 	}
 	if o.Codec == nil {
 		o.Codec = encoding.JSONCodec
@@ -134,10 +134,10 @@ func (c *Context) Service(service, method string, opts ...options.CallOption) re
 	}
 }
 
-func (c *Context) Object(service, key, method string, opts ...options.CallOption) restate.CallClient {
-	o := options.CallOptions{}
+func (c *Context) Object(service, key, method string, opts ...options.ClientOption) restate.CallClient {
+	o := options.ClientOptions{}
 	for _, opt := range opts {
-		opt.BeforeCall(&o)
+		opt.BeforeClient(&o)
 	}
 	if o.Codec == nil {
 		o.Codec = encoding.JSONCodec

--- a/options.go
+++ b/options.go
@@ -1,6 +1,8 @@
 package restate
 
 import (
+	"time"
+
 	"github.com/restatedev/sdk-go/encoding"
 	"github.com/restatedev/sdk-go/internal/options"
 )
@@ -77,13 +79,33 @@ type withHeaders struct {
 	headers map[string]string
 }
 
-var _ options.CallOption = withHeaders{}
+var _ options.RequestOption = withHeaders{}
+var _ options.SendOption = withHeaders{}
 
-func (w withHeaders) BeforeCall(opts *options.CallOptions) {
+func (w withHeaders) BeforeRequest(opts *options.RequestOptions) {
+	opts.Headers = w.headers
+}
+
+func (w withHeaders) BeforeSend(opts *options.SendOptions) {
 	opts.Headers = w.headers
 }
 
 // WithHeaders is an option to specify outgoing headers when making a call
 func WithHeaders(headers map[string]string) withHeaders {
 	return withHeaders{headers}
+}
+
+type withDelay struct {
+	delay time.Duration
+}
+
+var _ options.SendOption = withDelay{}
+
+func (w withDelay) BeforeSend(opts *options.SendOptions) {
+	opts.Delay = w.delay
+}
+
+// WithDelay is an [SendOption] to specify the duration to delay the request
+func WithDelay(delay time.Duration) withDelay {
+	return withDelay{delay}
 }

--- a/options.go
+++ b/options.go
@@ -8,7 +8,7 @@ import (
 )
 
 // re-export for use in generated code
-type CallOption = options.CallOption
+type ClientOption = options.ClientOption
 type ServiceDefinitionOption = options.ServiceDefinitionOption
 
 type withCodec struct {
@@ -20,7 +20,7 @@ var _ options.SetOption = withCodec{}
 var _ options.RunOption = withCodec{}
 var _ options.AwakeableOption = withCodec{}
 var _ options.ResolveAwakeableOption = withCodec{}
-var _ options.CallOption = withCodec{}
+var _ options.ClientOption = withCodec{}
 
 func (w withCodec) BeforeGet(opts *options.GetOptions)             { opts.Codec = w.codec }
 func (w withCodec) BeforeSet(opts *options.SetOptions)             { opts.Codec = w.codec }
@@ -29,7 +29,7 @@ func (w withCodec) BeforeAwakeable(opts *options.AwakeableOptions) { opts.Codec 
 func (w withCodec) BeforeResolveAwakeable(opts *options.ResolveAwakeableOptions) {
 	opts.Codec = w.codec
 }
-func (w withCodec) BeforeCall(opts *options.CallOptions) { opts.Codec = w.codec }
+func (w withCodec) BeforeClient(opts *options.ClientOptions) { opts.Codec = w.codec }
 
 // WithCodec is an option that can be provided to many different functions that perform (de)serialisation
 // in order to specify a custom codec with which to (de)serialise instead of the default of JSON.

--- a/protoc-gen-go-restate/restate.go
+++ b/protoc-gen-go-restate/restate.go
@@ -25,12 +25,12 @@ func generateClientStruct(g *protogen.GeneratedFile, service *protogen.Service, 
 	if serviceType == sdk.ServiceType_VIRTUAL_OBJECT {
 		g.P("key string")
 	}
-	g.P("options []", sdkPackage.Ident("CallOption"))
+	g.P("options []", sdkPackage.Ident("ClientOption"))
 	g.P("}")
 }
 
 func generateNewClientDefinitions(g *protogen.GeneratedFile, service *protogen.Service, clientName string) {
-	g.P("cOpts := append([]", sdkPackage.Ident("CallOption"), "{", sdkPackage.Ident("WithProtoJSON"), "}, opts...)")
+	g.P("cOpts := append([]", sdkPackage.Ident("ClientOption"), "{", sdkPackage.Ident("WithProtoJSON"), "}, opts...)")
 	g.P("return &", unexport(clientName), "{")
 	g.P("ctx,")
 	serviceType := proto.GetExtension(service.Desc.Options().(*descriptorpb.ServiceOptions), sdk.E_ServiceType).(sdk.ServiceType)
@@ -173,7 +173,7 @@ func genService(gen *protogen.Plugin, g *protogen.GeneratedFile, service *protog
 	if serviceType == sdk.ServiceType_VIRTUAL_OBJECT {
 		newClientSignature += ", key string"
 	}
-	newClientSignature += ", opts..." + g.QualifiedGoIdent(sdkPackage.Ident("CallOption")) + ") " + clientName
+	newClientSignature += ", opts..." + g.QualifiedGoIdent(sdkPackage.Ident("ClientOption")) + ") " + clientName
 
 	g.P("func ", newClientSignature, " {")
 	generateNewClientDefinitions(g, service, clientName)
@@ -261,7 +261,7 @@ func genService(gen *protogen.Plugin, g *protogen.GeneratedFile, service *protog
 
 func clientSignature(g *protogen.GeneratedFile, method *protogen.Method) string {
 	s := method.GoName + "("
-	s += "opts ..." + g.QualifiedGoIdent(sdkPackage.Ident("CallOption")) + ") ("
+	s += "opts ..." + g.QualifiedGoIdent(sdkPackage.Ident("ClientOption")) + ") ("
 	s += g.QualifiedGoIdent(sdkPackage.Ident("TypedCallClient")) + "[" + "*" + g.QualifiedGoIdent(method.Input.GoIdent) + ", *" + g.QualifiedGoIdent(method.Output.GoIdent) + "]"
 	s += ")"
 	return s
@@ -278,7 +278,7 @@ func genClientMethod(gen *protogen.Plugin, g *protogen.GeneratedFile, method *pr
 
 	g.P("cOpts := c.options")
 	g.P("if len(opts) > 0 {")
-	g.P("cOpts = append(append([]sdk_go.CallOption{}, cOpts...), opts...)")
+	g.P("cOpts = append(append([]sdk_go.ClientOption{}, cOpts...), opts...)")
 	g.P("}")
 	getClient := `c.ctx.`
 	switch serviceType {

--- a/test-services/kill.go
+++ b/test-services/kill.go
@@ -14,7 +14,7 @@ func init() {
 			Handler("recursiveCall", restate.NewObjectHandler(
 				func(ctx restate.ObjectContext, _ restate.Void) (restate.Void, error) {
 					awakeable := ctx.Awakeable()
-					ctx.Object("AwakeableHolder", "kill", "hold").Send(awakeable.Id(), 0)
+					ctx.Object("AwakeableHolder", "kill", "hold").Send(awakeable.Id())
 					if err := awakeable.Result(restate.Void{}); err != nil {
 						return restate.Void{}, err
 					}

--- a/test-services/nondeterministic.go
+++ b/test-services/nondeterministic.go
@@ -23,7 +23,7 @@ func init() {
 		return invocationCounts[countKey]%2 == 1
 	}
 	incrementCounter := func(ctx restate.ObjectContext) {
-		ctx.Object("Counter", ctx.Key(), "add").Send(int64(1), 0)
+		ctx.Object("Counter", ctx.Key(), "add").Send(int64(1))
 	}
 
 	REGISTRY.AddDefinition(
@@ -63,9 +63,9 @@ func init() {
 			Handler("backgroundInvokeWithDifferentTargets", restate.NewObjectHandler(
 				func(ctx restate.ObjectContext, _ restate.Void) (restate.Void, error) {
 					if doLeftAction(ctx) {
-						ctx.Object("Counter", "abc", "get").Send(restate.Void{}, 0)
+						ctx.Object("Counter", "abc", "get").Send(restate.Void{})
 					} else {
-						ctx.Object("Counter", "abc", "reset").Send(restate.Void{}, 0)
+						ctx.Object("Counter", "abc", "reset").Send(restate.Void{})
 					}
 
 					// This is required to cause a suspension after the non-deterministic operation

--- a/test-services/proxy.go
+++ b/test-services/proxy.go
@@ -47,7 +47,7 @@ func init() {
 				// We need to use []int because Golang takes the opinionated choice of treating []byte as Base64
 				func(ctx restate.Context, req ProxyRequest) (restate.Void, error) {
 					input := intArrayToByteArray(req.Message)
-					req.ToTarget(ctx).Send(input, 0)
+					req.ToTarget(ctx).Send(input)
 					return restate.Void{}, nil
 				})).
 			Handler("manyCalls", restate.NewServiceHandler(
@@ -58,7 +58,7 @@ func init() {
 					for _, req := range requests {
 						input := intArrayToByteArray(req.ProxyRequest.Message)
 						if req.OneWayCall {
-							req.ProxyRequest.ToTarget(ctx).Send(input, 0)
+							req.ProxyRequest.ToTarget(ctx).Send(input)
 						} else {
 							fut := req.ProxyRequest.ToTarget(ctx).RequestFuture(input)
 							if req.AwaitAtTheEnd {

--- a/test-services/upgradetest.go
+++ b/test-services/upgradetest.go
@@ -24,11 +24,11 @@ func init() {
 						return "", fmt.Errorf("executeComplex should not be invoked with version different from 1!")
 					}
 					awakeable := restate.AwakeableAs[string](ctx)
-					ctx.Object("AwakeableHolder", "upgrade", "hold").Send(awakeable.Id(), 0)
+					ctx.Object("AwakeableHolder", "upgrade", "hold").Send(awakeable.Id())
 					if _, err := awakeable.Result(); err != nil {
 						return "", err
 					}
-					ctx.Object("ListObject", "upgrade-test", "append").Send(version(), 0)
+					ctx.Object("ListObject", "upgrade-test", "append").Send(version())
 					return version(), nil
 				})))
 }


### PR DESCRIPTION
But keep codec as a property of the client, as this is a per method option and you might want to store a client and use it repeatedly with the codec set.