### PR TITLE
use native Go HTTP/2 server setup and graceful shutdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/restatedev/sdk-go
 
-go 1.22.0
-
-toolchain go1.23.6
+go 1.24
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.1


### PR DESCRIPTION
Replace manual HTTP/2 connection handling with native HTTP server setup using HTTP/2 protocols. This change simplifies the server code and provides better shutdown handling through a proper server.Shutdown call. Also updates Go version to 1.24.

The old implementation had a bug where once you start server you can't shut it down, even when context cancels, so it hand the client code, indefinitely.