### PR TITLE
Support schema derivation for protojson encoding

### DIFF
--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -1,7 +1,11 @@
 package encoding
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestVoid(t *testing.T) {
@@ -29,6 +33,65 @@ func TestVoid(t *testing.T) {
 			if err := Unmarshal(codec, []byte{1, 2, 3}, Void{}); err != nil {
 				t.Fatal(err)
 			}
+		})
+	}
+}
+
+var jsonSchemaCases = []struct {
+	object any
+	schema string
+}{
+	{
+		object: "abc",
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"string"}`,
+	},
+	{
+		object: 123,
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"integer"}`,
+	},
+	{
+		object: 1.1,
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"number"}`,
+	},
+	{
+		object: struct {
+			Foo string `json:"foo"`
+		}{},
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"foo":{"type":"string"}},"additionalProperties":false,"type":"object","required":["foo"]}`,
+	},
+	{
+		object: recursive{},
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://github.com/restatedev/sdk-go/encoding/recursive","$defs":{"recursive":{"$ref":"#"}},"properties":{"inner":{"$ref":"#/$defs/recursive"}},"additionalProperties":false,"type":"object","required":["inner"]}`,
+	},
+	{
+		object: nestedRecursiveA{},
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://github.com/restatedev/sdk-go/encoding/nested-recursive-a","$defs":{"nestedRecursiveA":{"$ref":"#"},"nestedRecursiveB":{"properties":{"inner":{"$ref":"#/$defs/nestedRecursiveC"}},"additionalProperties":false,"type":"object","required":["inner"]},"nestedRecursiveC":{"properties":{"inner":{"$ref":"#/$defs/nestedRecursiveA"}},"additionalProperties":false,"type":"object","required":["inner"]}},"properties":{"inner":{"$ref":"#/$defs/nestedRecursiveB"}},"additionalProperties":false,"type":"object","required":["inner"]}`,
+	},
+}
+
+type recursive struct {
+	Inner *recursive `json:"inner"`
+}
+
+type nestedRecursiveA struct {
+	Inner *nestedRecursiveB `json:"inner"`
+}
+
+type nestedRecursiveB struct {
+	Inner *nestedRecursiveC `json:"inner"`
+}
+
+type nestedRecursiveC struct {
+	Inner *nestedRecursiveA `json:"inner"`
+}
+
+func TestGenerateJsonSchema(t *testing.T) {
+	for _, test := range jsonSchemaCases {
+		t.Run(reflect.TypeOf(test.object).String(), func(t *testing.T) {
+			schema := generateJsonSchema(test.object)
+			data, err := json.Marshal(schema)
+			require.NoError(t, err)
+			require.Equal(t, test.schema, string(data))
 		})
 	}
 }

--- a/encoding/internal/protojsonschema/schema.go
+++ b/encoding/internal/protojsonschema/schema.go
@@ -1,0 +1,91 @@
+package protojsonschema
+
+import (
+	"reflect"
+
+	"github.com/invopop/jsonschema"
+	"github.com/restatedev/sdk-go/encoding/internal/util"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+var protoMessageType = reflect.TypeOf((*protoreflect.ProtoMessage)(nil)).Elem()
+var protoEnumType = reflect.TypeOf((*protoreflect.Enum)(nil)).Elem()
+
+func descriptor(typ reflect.Type) protoreflect.Descriptor {
+	if typ.Implements(protoEnumType) {
+		zero := reflect.Zero(typ).Interface().(protoreflect.Enum)
+		return zero.Descriptor()
+	}
+
+	pointerTyp := reflect.PointerTo(typ)
+	if pointerTyp.Implements(protoMessageType) {
+		zero := reflect.Zero(pointerTyp).Interface().(protoreflect.ProtoMessage)
+		return zero.ProtoReflect().Descriptor()
+	}
+
+	return nil
+}
+
+func GenerateSchema(v any) *jsonschema.Schema {
+	reflector := jsonschema.Reflector{
+		// Unfortunately we can't enable this due to a panic bug https://github.com/invopop/jsonschema/issues/163
+		// So we use ExpandSchema instead, which has the same effect but without the panic
+		// ExpandedStruct: true,
+		KeyNamer: func(fieldName string) string {
+			return jsonCamelCase(fieldName)
+		},
+		Lookup: func(typ reflect.Type) jsonschema.ID {
+			desc := descriptor(typ)
+			if desc == nil {
+				return jsonschema.EmptyID
+			}
+
+			id := jsonschema.ID("https://" + typ.PkgPath())
+			if err := id.Validate(); err != nil {
+				return jsonschema.EmptyID
+			}
+
+			return id.Add(string(desc.FullName()))
+		},
+		Mapper: func(typ reflect.Type) *jsonschema.Schema {
+			desc := descriptor(typ)
+			if desc == nil {
+				return nil
+			}
+
+			schemaFn, ok := wellKnownToSchemaFns[string(desc.FullName())]
+			if !ok {
+				return nil
+			}
+
+			return schemaFn(desc)
+		},
+		Namer: func(typ reflect.Type) string {
+			desc := descriptor(typ)
+			if desc == nil {
+				return ""
+			}
+
+			return string(desc.FullName())
+		},
+	}
+	return util.ExpandSchema(reflector.Reflect(v))
+}
+
+// jsonCamelCase converts a snake_case identifier to a camelCase identifier,
+// according to the protobuf JSON specification.
+func jsonCamelCase(s string) string {
+	var b []byte
+	var wasUnderscore bool
+	for i := 0; i < len(s); i++ { // proto identifiers are always ASCII
+		c := s[i]
+		if c != '_' {
+			if wasUnderscore && 'a' <= c && c <= 'z' {
+				c -= 'a' - 'A' // convert to uppercase
+			}
+			b = append(b, c)
+		}
+		wasUnderscore = c == '_'
+	}
+	return string(b)
+}

--- a/encoding/internal/protojsonschema/schema_test.go
+++ b/encoding/internal/protojsonschema/schema_test.go
@@ -1,0 +1,128 @@
+package protojsonschema_test
+
+import (
+	"testing"
+
+	"github.com/restatedev/sdk-go/encoding/internal/protojsonschema"
+	helloworld "github.com/restatedev/sdk-go/examples/codegen/proto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+type testCase struct {
+	desc   string
+	msg    proto.Message
+	schema string
+}
+
+var testCases = []testCase{
+	{
+		desc:   "HelloRequest",
+		msg:    &helloworld.HelloRequest{},
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://github.com/restatedev/sdk-go/examples/codegen/proto/helloworld.HelloRequest","$defs":{"helloworld.HelloRequest":{"$ref":"#"}},"properties":{"name":{"type":"string"}},"additionalProperties":false,"type":"object"}`,
+	},
+	{
+		desc:   "WatchRequest",
+		msg:    &helloworld.WatchRequest{},
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://github.com/restatedev/sdk-go/examples/codegen/proto/helloworld.WatchRequest","$defs":{"helloworld.WatchRequest":{"$ref":"#"}},"properties":{"timeoutMillis":{"type":"integer"}},"additionalProperties":false,"type":"object"}`,
+	},
+	{
+		desc:   "google.protobuf.Duration",
+		msg:    &durationpb.Duration{},
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/durationpb/google.protobuf.Duration","type":"string","pattern":"^[-\\+]?([0-9]+\\.?[0-9]*|\\.[0-9]+)s$","format":"regex"}`,
+	},
+	{
+		desc:   "google.protobuf.Timestamp",
+		msg:    &timestamppb.Timestamp{},
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/timestamppb/google.protobuf.Timestamp","type":"string","format":"date-time"}`,
+	},
+	{
+		desc:   "google.protobuf.Empty",
+		msg:    &emptypb.Empty{},
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/emptypb/google.protobuf.Empty","type":"object"}`,
+	},
+	{
+		desc:   "google.protobuf.Any",
+		msg:    &anypb.Any{},
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/anypb/google.protobuf.Any","properties":{"@type":{"type":"string"},"value":{"type":"string","format":"binary"}},"additionalProperties":true,"type":"object"}`,
+	},
+	{
+		desc:   "google.protobuf.FieldMask",
+		msg:    &fieldmaskpb.FieldMask{},
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/fieldmaskpb/google.protobuf.FieldMask","type":"string"}`,
+	},
+	{
+		desc:   "google.protobuf.Struct",
+		msg:    &structpb.Struct{},
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/structpb/google.protobuf.Struct","additionalProperties":{"oneOf":[{"type":"null"},{"type":"number"},{"type":"string"},{"type":"boolean"},{"type":"array"},{"additionalProperties":true,"type":"object"}]},"type":"object"}`,
+	},
+	{
+		desc:   "google.protobuf.Value",
+		msg:    &structpb.Value{},
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/structpb/google.protobuf.Value","oneOf":[{"type":"null"},{"type":"number"},{"type":"string"},{"type":"boolean"},{"type":"array"},{"additionalProperties":true,"type":"object"}]}`,
+	},
+	{
+		desc:   "google.protobuf.StringValue",
+		msg:    wrapperspb.String(""),
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/wrapperspb/google.protobuf.StringValue","type":"string"}`,
+	},
+	{
+		desc:   "google.protobuf.BytesValue",
+		msg:    wrapperspb.Bytes(nil),
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/wrapperspb/google.protobuf.BytesValue","type":"string","format":"binary"}`,
+	},
+	{
+		desc:   "google.protobuf.BoolValue",
+		msg:    wrapperspb.Bool(false),
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/wrapperspb/google.protobuf.BoolValue","type":"boolean"}`,
+	},
+	{
+		desc:   "google.protobuf.DoubleValue",
+		msg:    wrapperspb.Double(0.0),
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/wrapperspb/google.protobuf.DoubleValue","oneOf":[{"type":"number"},{"type":"string"}]}`,
+	},
+	{
+		desc:   "google.protobuf.Int64Value",
+		msg:    wrapperspb.Int64(0),
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/wrapperspb/google.protobuf.Int64Value","oneOf":[{"type":"number"},{"type":"string"}]}`,
+	},
+	{
+		desc:   "google.protobuf.UInt64Value",
+		msg:    wrapperspb.UInt64(0),
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/wrapperspb/google.protobuf.UInt64Value","oneOf":[{"type":"number"},{"type":"string"}]}`,
+	},
+	{
+		desc:   "google.protobuf.FloatValue",
+		msg:    wrapperspb.Float(0.0),
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/wrapperspb/google.protobuf.FloatValue","oneOf":[{"type":"number"},{"type":"string"}]}`,
+	},
+	{
+		desc:   "google.protobuf.Int32Value",
+		msg:    wrapperspb.Int32(0),
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/wrapperspb/google.protobuf.Int32Value","type":"number"}`,
+	},
+	{
+		desc:   "google.protobuf.Uint32Value",
+		msg:    wrapperspb.UInt32(0),
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/wrapperspb/google.protobuf.UInt32Value","type":"number"}`,
+	},
+}
+
+func TestSchema(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			schema := protojsonschema.GenerateSchema(testCase.msg)
+			bytes, err := schema.MarshalJSON()
+			require.NoError(t, err)
+			require.Equal(t, testCase.schema, string(bytes))
+		})
+
+	}
+}

--- a/encoding/internal/protojsonschema/schema_test.go
+++ b/encoding/internal/protojsonschema/schema_test.go
@@ -46,7 +46,7 @@ var testCases = []testCase{
 	{
 		desc:   "google.protobuf.Empty",
 		msg:    &emptypb.Empty{},
-		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/emptypb/google.protobuf.Empty","type":"object"}`,
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/emptypb/google.protobuf.Empty","additionalProperties":false,"type":"object"}`,
 	},
 	{
 		desc:   "google.protobuf.Any",
@@ -61,12 +61,12 @@ var testCases = []testCase{
 	{
 		desc:   "google.protobuf.Struct",
 		msg:    &structpb.Struct{},
-		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/structpb/google.protobuf.Struct","additionalProperties":{"oneOf":[{"type":"null"},{"type":"number"},{"type":"string"},{"type":"boolean"},{"type":"array"},{"additionalProperties":true,"type":"object"}]},"type":"object"}`,
+		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/structpb/google.protobuf.Struct","additionalProperties":true,"type":"object"}`,
 	},
 	{
 		desc:   "google.protobuf.Value",
 		msg:    &structpb.Value{},
-		schema: `{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://google.golang.org/protobuf/types/known/structpb/google.protobuf.Value","oneOf":[{"type":"null"},{"type":"number"},{"type":"string"},{"type":"boolean"},{"type":"array"},{"additionalProperties":true,"type":"object"}]}`,
+		schema: `true`,
 	},
 	{
 		desc:   "google.protobuf.StringValue",

--- a/encoding/internal/protojsonschema/wellknown.go
+++ b/encoding/internal/protojsonschema/wellknown.go
@@ -22,7 +22,8 @@ var wellKnownToSchemaFns = map[string]func(protoreflect.Descriptor) *jsonschema.
 	},
 	"google.protobuf.Empty": func(d protoreflect.Descriptor) *jsonschema.Schema {
 		return &jsonschema.Schema{
-			Type: "object",
+			Type:                 "object",
+			AdditionalProperties: jsonschema.FalseSchema,
 		}
 	},
 	"google.protobuf.Any": func(d protoreflect.Descriptor) *jsonschema.Schema {
@@ -49,36 +50,12 @@ var wellKnownToSchemaFns = map[string]func(protoreflect.Descriptor) *jsonschema.
 
 	"google.protobuf.Struct": func(d protoreflect.Descriptor) *jsonschema.Schema {
 		return &jsonschema.Schema{
-			Type: "object",
-			AdditionalProperties: &jsonschema.Schema{
-				OneOf: []*jsonschema.Schema{
-					&jsonschema.Schema{Type: "null"},
-					&jsonschema.Schema{Type: "number"},
-					&jsonschema.Schema{Type: "string"},
-					&jsonschema.Schema{Type: "boolean"},
-					&jsonschema.Schema{Type: "array"},
-					&jsonschema.Schema{
-						Type:                 "object",
-						AdditionalProperties: jsonschema.TrueSchema,
-					},
-				},
-			},
+			Type:                 "object",
+			AdditionalProperties: jsonschema.TrueSchema,
 		}
 	},
 	"google.protobuf.Value": func(d protoreflect.Descriptor) *jsonschema.Schema {
-		return &jsonschema.Schema{
-			OneOf: []*jsonschema.Schema{
-				&jsonschema.Schema{Type: "null"},
-				&jsonschema.Schema{Type: "number"},
-				&jsonschema.Schema{Type: "string"},
-				&jsonschema.Schema{Type: "boolean"},
-				&jsonschema.Schema{Type: "array"},
-				&jsonschema.Schema{
-					Type:                 "object",
-					AdditionalProperties: jsonschema.TrueSchema,
-				},
-			},
-		}
+		return jsonschema.TrueSchema
 	},
 	"google.protobuf.NullValue": func(d protoreflect.Descriptor) *jsonschema.Schema {
 		return &jsonschema.Schema{

--- a/encoding/internal/protojsonschema/wellknown.go
+++ b/encoding/internal/protojsonschema/wellknown.go
@@ -1,0 +1,124 @@
+package protojsonschema
+
+import (
+	"github.com/invopop/jsonschema"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+var wellKnownToSchemaFns = map[string]func(protoreflect.Descriptor) *jsonschema.Schema{
+	"google.protobuf.Duration": func(d protoreflect.Descriptor) *jsonschema.Schema {
+		return &jsonschema.Schema{
+			Type:    "string",
+			Format:  "regex",
+			Pattern: `^[-\+]?([0-9]+\.?[0-9]*|\.[0-9]+)s$`,
+		}
+	},
+	"google.protobuf.Timestamp": func(d protoreflect.Descriptor) *jsonschema.Schema {
+		return &jsonschema.Schema{
+			Type:   "string",
+			Format: "date-time",
+		}
+	},
+	"google.protobuf.Empty": func(d protoreflect.Descriptor) *jsonschema.Schema {
+		return &jsonschema.Schema{
+			Type: "object",
+		}
+	},
+	"google.protobuf.Any": func(d protoreflect.Descriptor) *jsonschema.Schema {
+		return &jsonschema.Schema{
+			Type: "object",
+			Properties: orderedmap.New[string, *jsonschema.Schema](orderedmap.WithInitialData[string, *jsonschema.Schema](
+				orderedmap.Pair[string, *jsonschema.Schema]{
+					Key:   "@type",
+					Value: &jsonschema.Schema{Type: "string"},
+				},
+				orderedmap.Pair[string, *jsonschema.Schema]{
+					Key:   "value",
+					Value: &jsonschema.Schema{Type: "string", Format: "binary"},
+				},
+			)),
+			AdditionalProperties: jsonschema.TrueSchema,
+		}
+	},
+	"google.protobuf.FieldMask": func(d protoreflect.Descriptor) *jsonschema.Schema {
+		return &jsonschema.Schema{
+			Type: "string",
+		}
+	},
+
+	"google.protobuf.Struct": func(d protoreflect.Descriptor) *jsonschema.Schema {
+		return &jsonschema.Schema{
+			Type: "object",
+			AdditionalProperties: &jsonschema.Schema{
+				OneOf: []*jsonschema.Schema{
+					&jsonschema.Schema{Type: "null"},
+					&jsonschema.Schema{Type: "number"},
+					&jsonschema.Schema{Type: "string"},
+					&jsonschema.Schema{Type: "boolean"},
+					&jsonschema.Schema{Type: "array"},
+					&jsonschema.Schema{
+						Type:                 "object",
+						AdditionalProperties: jsonschema.TrueSchema,
+					},
+				},
+			},
+		}
+	},
+	"google.protobuf.Value": func(d protoreflect.Descriptor) *jsonschema.Schema {
+		return &jsonschema.Schema{
+			OneOf: []*jsonschema.Schema{
+				&jsonschema.Schema{Type: "null"},
+				&jsonschema.Schema{Type: "number"},
+				&jsonschema.Schema{Type: "string"},
+				&jsonschema.Schema{Type: "boolean"},
+				&jsonschema.Schema{Type: "array"},
+				&jsonschema.Schema{
+					Type:                 "object",
+					AdditionalProperties: jsonschema.TrueSchema,
+				},
+			},
+		}
+	},
+	"google.protobuf.NullValue": func(d protoreflect.Descriptor) *jsonschema.Schema {
+		return &jsonschema.Schema{
+			Type: "null",
+		}
+	},
+	"google.protobuf.StringValue": func(d protoreflect.Descriptor) *jsonschema.Schema {
+		return &jsonschema.Schema{
+			Type: "string",
+		}
+	},
+	"google.protobuf.BytesValue": func(d protoreflect.Descriptor) *jsonschema.Schema {
+		return &jsonschema.Schema{
+			Type:   "string",
+			Format: "binary",
+		}
+	},
+	"google.protobuf.BoolValue": func(d protoreflect.Descriptor) *jsonschema.Schema {
+		return &jsonschema.Schema{
+			Type: "boolean",
+		}
+	},
+	"google.protobuf.DoubleValue": google64BitNumberValue,
+	"google.protobuf.Int64Value":  google64BitNumberValue,
+	"google.protobuf.UInt64Value": google64BitNumberValue,
+	"google.protobuf.FloatValue":  google64BitNumberValue,
+	"google.protobuf.Int32Value":  google32BitNumberValue,
+	"google.protobuf.UInt32Value": google32BitNumberValue,
+}
+
+var google64BitNumberValue = func(d protoreflect.Descriptor) *jsonschema.Schema {
+	return &jsonschema.Schema{
+		OneOf: []*jsonschema.Schema{
+			&jsonschema.Schema{Type: "number"},
+			&jsonschema.Schema{Type: "string"},
+		},
+	}
+}
+var google32BitNumberValue = func(d protoreflect.Descriptor) *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "number",
+	}
+}

--- a/encoding/internal/util/util.go
+++ b/encoding/internal/util/util.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"strings"
+
+	"github.com/invopop/jsonschema"
+)
+
+// Schemas that have a top-level ref can be problematic for some parsers, like the playground in the UI.
+// To be more forgiving, we can yank the definition up to the top level
+func ExpandSchema(rootSchema *jsonschema.Schema) *jsonschema.Schema {
+	if !strings.HasPrefix(rootSchema.Ref, `#/$defs/`) {
+		return rootSchema
+	}
+	defName := rootSchema.Ref[len(`#/$defs/`):]
+	def, ok := rootSchema.Definitions[defName]
+	if !ok {
+		return rootSchema
+	}
+	// allow references to #/$defs/name to still work by redirecting to the root
+	rootSchema.Definitions[defName] = &jsonschema.Schema{Ref: "#"}
+
+	expandedSchema := &*def
+	expandedSchema.ID = rootSchema.ID
+	expandedSchema.Version = rootSchema.Version
+	expandedSchema.Definitions = rootSchema.Definitions
+
+	return expandedSchema
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mr-tron/base58 v1.2.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tetratelabs/wazero v1.9.0
+	github.com/wk8/go-ordered-map/v2 v2.1.8
 	go.opentelemetry.io/otel v1.28.0
 	golang.org/x/net v0.23.0
 	google.golang.org/protobuf v1.36.5
@@ -25,7 +26,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	golang.org/x/text v0.14.0 // indirect


### PR DESCRIPTION
Uses the existing json schema deriver, with some special casing for well known proto types, setting the correct camelCase json name.

Also expand structs correctly, so we don't have top level references, which our playground doesn't like.