### PR TITLE
Few changes in the Rand API

### DIFF
--- a/facilitators.go
+++ b/facilitators.go
@@ -1,9 +1,12 @@
 package restate
 
 import (
+	rand2 "math/rand/v2"
+	"time"
+
+	"github.com/google/uuid"
 	"github.com/restatedev/sdk-go/internal/converters"
 	"github.com/restatedev/sdk-go/internal/restatecontext"
-	"time"
 
 	"github.com/restatedev/sdk-go/internal/options"
 	"github.com/restatedev/sdk-go/internal/rand"
@@ -14,6 +17,18 @@ import (
 // This source is not safe for use inside .Run()
 func Rand(ctx Context) rand.Rand {
 	return ctx.inner().Rand()
+}
+
+// RandUUID returns a random UUID seeded deterministically for a given invocation.
+func RandUUID(ctx Context) uuid.UUID {
+	return ctx.inner().Rand().UUID()
+}
+
+// RandSource returns a random source to be used with math rand implementations.
+//
+// To create a random implementation, use `rand2.New(RandSource(ctx))`
+func RandSource(ctx Context) rand2.Source {
+	return ctx.inner().Rand().Source()
 }
 
 // Sleep for the duration d. Can return a terminal error in the case where the invocation was cancelled mid-sleep.

--- a/internal/rand/rand.go
+++ b/internal/rand/rand.go
@@ -8,12 +8,15 @@ import (
 )
 
 type Rand interface {
+	// Deprecated: Use restate.RandUUID directly, instead of restate.Rand().UUID()
 	UUID() uuid.UUID
 	Float64() float64
 	Uint64() uint64
 	// Source returns a deterministic random source that can be provided to math/rand.New()
 	// and math/rand/v2.New(). The v2 version of rand is strongly recommended where Go 1.22
 	// is used, and once this library begins to depend on 1.22, it will be embedded in Rand.
+	//
+	// Deprecated: Use restate.RandSource directly, instead of restate.Rand().Source()
 	Source() Source
 }
 

--- a/test-services/failing.go
+++ b/test-services/failing.go
@@ -21,7 +21,7 @@ func init() {
 				})).
 			Handler("callTerminallyFailingCall", restate.NewObjectHandler(
 				func(ctx restate.ObjectContext, errorMessage string) (string, error) {
-					if _, err := restate.Object[restate.Void](ctx, "Failing", restate.Rand(ctx).UUID().String(), "terminallyFailingCall").Request(errorMessage); err != nil {
+					if _, err := restate.Object[restate.Void](ctx, "Failing", restate.RandUUID(ctx).String(), "terminallyFailingCall").Request(errorMessage); err != nil {
 						return "", err
 					}
 


### PR DESCRIPTION
* Add facilitators for RandUUID, RandSource
* Deprecate our internal interface `Rand.UUID` and `Rand.Source`. This way we can remove those methods later on, and replace the return value of `Rand` to be just the standard library math rand v2

Part of #102