### PR TITLE
feat: add RunVoid syntactic sugar

### DIFF
--- a/facilitators.go
+++ b/facilitators.go
@@ -344,6 +344,22 @@ func RunAsync[T any](ctx Context, fn func(ctx RunContext) (T, error), options ..
 	}, options...)}
 }
 
+// RunVoid runs the function (fn), storing final results (including terminal errors)
+// durably in the journal, or otherwise for transient errors stopping execution
+// so Restate can retry the invocation. Replays will produce the same value, so
+// all non-deterministic operations (eg, generating a unique ID) *must* happen
+// inside RunVoid blocks.
+//
+// This is similar to Run, but for functions that don't return a value.
+func RunVoid(ctx Context, fn func(ctx RunContext) error, options ...options.RunOption) error {
+	var output Void
+	err := ctx.inner().Run(func(ctx RunContext) (any, error) {
+		return nil, fn(ctx)
+	}, &output, options...)
+
+	return err
+}
+
 // RunAsyncFuture is a 'promise' for a RunAsync operation.
 type RunAsyncFuture[T any] interface {
 	// Result blocks on receiving the RunAsync result, returning the value it was

--- a/test-services/failing.go
+++ b/test-services/failing.go
@@ -39,9 +39,10 @@ func init() {
 				})).
 			Handler("terminallyFailingSideEffect", restate.NewObjectHandler(
 				func(ctx restate.ObjectContext, errorMessage string) (restate.Void, error) {
-					return restate.Run(ctx, func(ctx restate.RunContext) (restate.Void, error) {
-						return restate.Void{}, restate.TerminalErrorf("%s", errorMessage)
+					err := restate.RunVoid(ctx, func(ctx restate.RunContext) error {
+						return restate.TerminalErrorf("%s", errorMessage)
 					})
+					return restate.Void{}, err
 				})).
 			Handler("sideEffectSucceedsAfterGivenAttempts", restate.NewObjectHandler(
 				func(ctx restate.ObjectContext, minimumAttempts int32) (int32, error) {

--- a/test-services/interpreter.go
+++ b/test-services/interpreter.go
@@ -128,9 +128,9 @@ func interpret(ctx restate.ObjectContext, layer uint32, value Program) error {
 			}
 			break
 		case SlowSideEffect:
-			_, err := restate.Run[restate.Void](ctx, func(ctx restate.RunContext) (restate.Void, error) {
+			err := restate.RunVoid(ctx, func(ctx restate.RunContext) error {
 				time.Sleep(1 * time.Millisecond)
-				return restate.Void{}, nil
+				return nil
 			})
 			if err != nil {
 				return err
@@ -145,11 +145,11 @@ func interpret(ctx restate.ObjectContext, layer uint32, value Program) error {
 			}
 			break
 		case ThrowingSideEffect:
-			_, err := restate.Run[restate.Void](ctx, func(ctx restate.RunContext) (restate.Void, error) {
+			err := restate.RunVoid(ctx, func(ctx restate.RunContext) error {
 				if rand.IntN(2) == 1 {
-					return restate.Void{}, fmt.Errorf("Too many 'if err != nil', and no there's no feelings attached to it at all.")
+					return fmt.Errorf("Too many 'if err != nil', and no there's no feelings attached to it at all.")
 				}
-				return restate.Void{}, nil
+				return nil
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
As discussed with @slinkydeveloper on slack.

`restate.RunVoid` is a shorter alternative to `restate.Run[restate.Void]`.

Before
```go
_, err = restate.Run[restate.Void](ctx, func(stepCtx restate.RunContext) (restate.Void, error) {
    return restate.Void{}, DoStuff()
}) 
```
After
```go
err = restate.RunVoid(ctx, func(stepCtx restate.RunContext) error {
  return DoStuff()  
})
```

I don't mind the name `RunVoid` but I don't mind renaming it either, just lmk :)