### PR TITLE
Close wasm module when *Core is gc'd

### DIFF
--- a/internal/statemachine/wasm.go
+++ b/internal/statemachine/wasm.go
@@ -226,7 +226,7 @@ func NewCore(ctx context.Context) (*Core, error) {
     // Adds a finalizer to `core` to correctly close the WASM module, deallocating its memory.
     // This gets invoked when the Pool decides to deallocate some of its entries. 
 	runtime.AddCleanup(core, func(instance api.Module) {
-		core.instance.Close(context.Background())
+		instance.Close(context.Background())
 	}, instance)
 
 	return core, nil


### PR DESCRIPTION
It appears that wasm Module memory leaks by default; its stored in a linked list in the global `_wazeroRuntime` and Close *must* be called to clean it up.