### PR TITLE
Add context propagation for ingress clients and restate servers

### DIFF
--- a/internal/ingress/ingress.go
+++ b/internal/ingress/ingress.go
@@ -121,6 +121,15 @@ func (c *Client) do(ctx context.Context, httpMethod, path string, requestData an
 	if err != nil {
 		return err
 	}
+
+	// Run context propagators so callers can inject values (e.g. trace context) into the request context.
+	for _, p := range c.clientOpts.Propagators {
+		ctx, err = p.Propagate(ctx, req)
+		if err != nil {
+			return fmt.Errorf("context propagator failed: %w", err)
+		}
+	}
+
 	req = req.WithContext(ctx)
 
 	// Figure out the content type

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -1,11 +1,17 @@
 package options
 
 import (
+	"context"
 	"net/http"
 	"time"
 
 	"github.com/restatedev/sdk-go/encoding"
 )
+
+// IngressContextPropagator enriches the context before an ingress HTTP request is made.
+type IngressContextPropagator interface {
+	Propagate(ctx context.Context, request *http.Request) (context.Context, error)
+}
 
 // OnMaxAttempts determines behavior when max attempts is reached.
 type OnMaxAttempts string
@@ -260,9 +266,10 @@ type ServiceDefinitionOption interface {
 }
 
 type IngressClientOptions struct {
-	HttpClient *http.Client
-	AuthKey    string
-	Codec      encoding.PayloadCodec
+	HttpClient  *http.Client
+	AuthKey     string
+	Codec       encoding.PayloadCodec
+	Propagators []IngressContextPropagator
 }
 
 type IngressClientOption interface {

--- a/internal/restatecontext/ctx.go
+++ b/internal/restatecontext/ctx.go
@@ -30,6 +30,15 @@ type Request struct {
 	Body []byte
 }
 
+// ContextPropagator enriches the context passed to invocation handlers. Propagators are run after
+// the Restate context is initialised. The [Request] provides access to request headers, attempt
+// headers (e.g. W3C trace context from Restate), and the invocation ID. The returned
+// context.Context is re-wrapped into a new Restate context and passed to the next propagator and
+// ultimately to the handler.
+type ContextPropagator interface {
+	Propagate(ctx context.Context, req *Request) (context.Context, error)
+}
+
 type Context interface {
 	context.Context
 	Log() *slog.Logger

--- a/internal/restatecontext/execute_invocation.go
+++ b/internal/restatecontext/execute_invocation.go
@@ -14,7 +14,7 @@ import (
 	"github.com/restatedev/sdk-go/internal/statemachine"
 )
 
-func ExecuteInvocation(ctx context.Context, logger *slog.Logger, stateMachine *statemachine.StateMachine, conn io.ReadWriteCloser, handler Handler, dropReplayLogs bool, logHandler slog.Handler, attemptHeaders map[string][]string) error {
+func ExecuteInvocation(ctx context.Context, logger *slog.Logger, stateMachine *statemachine.StateMachine, conn io.ReadWriteCloser, handler Handler, dropReplayLogs bool, logHandler slog.Handler, attemptHeaders map[string][]string, propagators []ContextPropagator) error {
 	// Let's read the input entry
 	invocationInput, err := stateMachine.SysInput(ctx)
 	if err != nil {
@@ -30,11 +30,11 @@ func ExecuteInvocation(ctx context.Context, logger *slog.Logger, stateMachine *s
 	restateCtx := newContext(ctx, stateMachine, invocationInput, conn, attemptHeaders, dropReplayLogs, logHandler)
 
 	// Invoke the handler
-	invoke(restateCtx, handler, logger)
+	invoke(restateCtx, propagators, handler, logger)
 	return nil
 }
 
-func invoke(restateCtx *ctx, handler Handler, logger *slog.Logger) {
+func invoke(restateCtx *ctx, propagators []ContextPropagator, handler Handler, logger *slog.Logger) {
 	// Run read loop on a goroutine
 	go func(restateCtx *ctx, logger *slog.Logger) { restateCtx.readInputLoop(logger) }(restateCtx, logger)
 
@@ -70,9 +70,25 @@ func invoke(restateCtx *ctx, handler Handler, logger *slog.Logger) {
 
 	restateCtx.internalLogger.InfoContext(restateCtx, "Handling invocation")
 
-	var bytes []byte
+	// Run context propagators to build the call context. Each propagator receives the current
+	// (potentially already-enriched) context and returns a new one with additional values.
+	// The result is wrapped back into a full Restate context so subsequent propagators and the
+	// handler all receive a context.Context that also satisfies restate.Context.
+	callCtx := Context(restateCtx)
 	var err error
-	bytes, err = handler.Call(restateCtx, restateCtx.request.Body)
+	for _, p := range propagators {
+		var enriched context.Context
+		enriched, err = p.Propagate(callCtx, &restateCtx.request)
+		if err != nil {
+			break
+		}
+		callCtx = restateCtx.Wrap(enriched)
+	}
+
+	var bytes []byte
+	if err == nil {
+		bytes, err = handler.Call(callCtx, restateCtx.request.Body)
+	}
 
 	if err != nil && errors.IsTerminalError(err) {
 		restateCtx.internalLogger.LogAttrs(restateCtx, slog.LevelWarn, "Invocation returned a terminal failure", log.Error(err))

--- a/options.go
+++ b/options.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/restatedev/sdk-go/encoding"
 	"github.com/restatedev/sdk-go/internal/options"
+	"github.com/restatedev/sdk-go/internal/restatecontext"
 )
 
 // re-export options types so users can create arrays of them and functions that accept/return them
@@ -32,6 +33,15 @@ type OnMaxAttempts = options.OnMaxAttempts
 // Retry policy option builders
 type InvocationRetryPolicyOption = options.InvocationRetryPolicyOption
 type IngressClientOption = options.IngressClientOption
+
+// ContextPropagator enriches the context passed to invocation handlers. The [Request] argument
+// gives access to request headers, attempt headers (e.g. W3C trace context forwarded by Restate),
+// and the invocation ID. Use [server.Restate.WithPropagator] to register propagators on a server.
+type ContextPropagator = restatecontext.ContextPropagator
+
+// IngressContextPropagator enriches the context before an ingress HTTP request is made.
+// Use [WithPropagator] to add one to an ingress client.
+type IngressContextPropagator = options.IngressContextPropagator
 
 type withCodec struct {
 	codec encoding.Codec
@@ -641,4 +651,19 @@ type withAuthKey struct {
 
 func (w withAuthKey) BeforeIngress(opts *options.IngressClientOptions) {
 	opts.AuthKey = w.authKey
+}
+
+// WithPropagator is an [IngressClientOption] that adds an [IngressContextPropagator] to the ingress
+// client. Propagators are run in order before each HTTP request, allowing callers to enrich the
+// request context (e.g. to inject outgoing trace headers).
+func WithPropagator(p options.IngressContextPropagator) withPropagator {
+	return withPropagator{p}
+}
+
+type withPropagator struct {
+	propagator options.IngressContextPropagator
+}
+
+func (w withPropagator) BeforeIngress(opts *options.IngressClientOptions) {
+	opts.Propagators = append(opts.Propagators, w.propagator)
 }

--- a/server/restate.go
+++ b/server/restate.go
@@ -66,6 +66,7 @@ type Restate struct {
 	keyIDs         []string
 	keySet         identity.KeySetV1
 	protocolMode   internal.ProtocolMode
+	propagators    []restate.ContextPropagator
 }
 
 // NewRestate creates a new instance of Restate server
@@ -88,6 +89,14 @@ func (r *Restate) WithLogger(h slog.Handler, dropReplayLogs bool) *Restate {
 	r.dropReplayLogs = dropReplayLogs
 	r.systemLog = slog.New(log.NewRestateContextHandler(h))
 	r.logHandler = h
+	return r
+}
+
+// WithPropagator adds one or more [restate.ContextPropagator]s that will be run after the Restate context
+// is initialised for each invocation. Propagators are called in order and can enrich the context
+// passed to the handler, for example by extracting trace context from attempt headers.
+func (r *Restate) WithPropagator(propagators ...restate.ContextPropagator) *Restate {
+	r.propagators = append(r.propagators, propagators...)
 	return r
 }
 
@@ -576,7 +585,7 @@ func (r *Restate) handleInvokeRequest(service, method string, writer http.Respon
 	restatecontext.BufPool.Put(buf)
 
 	// Run the handler
-	if err := restatecontext.ExecuteInvocation(ctx, logger, stateMachine, conn, handler, r.dropReplayLogs, logHandler, request.Header); err != nil {
+	if err := restatecontext.ExecuteInvocation(ctx, logger, stateMachine, conn, handler, r.dropReplayLogs, logHandler, request.Header, r.propagators); err != nil {
 		r.systemLog.LogAttrs(ctx, slog.LevelError, "Failed to handle invocation", log.Error(err))
 	}
 }


### PR DESCRIPTION
## Add context propagation for ingress clients and Restate servers

### Summary

Introduces a `ContextPropagator` extension point for both the Restate server and ingress clients, enabling callers to enrich the Go `context.Context` before handlers are invoked or outgoing HTTP requests are made. The primary use case is propagating observability data such as W3C trace context (OpenTelemetry), but the interface is general-purpose.

We're internally planning to use this to propagate authentication headers to/from the restate context. (We have already tested this fork internally to ensure it functions as expected.)

### Changes

**Server-side (`ContextPropagator`)**
- Adds the `ContextPropagator` interface to `internal/restatecontext` (and re-exported from the top-level `options.go`). Each propagator receives the current context and the `Request` (which exposes request/attempt headers and invocation ID) and returns an enriched `context.Context`.
- Adds `(*Restate).WithPropagator(...ContextPropagator) *Restate` to `server/restate.go`, allowing one or more propagators to be registered on a server instance.
- Propagators are run in registration order after the Restate context is initialised, before the handler is called. Each propagator's output context is re-wrapped into a full Restate context so subsequent propagators and the handler all receive a `restate.Context`.

**Ingress client-side (`IngressContextPropagator`)**
- Adds the `IngressContextPropagator` interface to `internal/options` (and re-exported from `options.go`). Each propagator receives the current context and the outgoing `*http.Request` and returns an enriched context.
- Adds the `WithPropagator(IngressContextPropagator) IngressClientOption` functional option, allowing propagators to be attached to ingress clients.
- Propagators are run in order inside `Client.do` before the request is dispatched, enabling injection of outgoing trace headers or other context values.

### Usage example

```go
// Server
server.NewRestate().
    WithPropagator(authHeaderPropagator).
    Bind(restate.Reflect(myService))

// Ingress client
client := ingress.NewClient("http://localhost:8080",
    restate.WithPropagator(authorizationPropagator),
)
```