### PR TITLE
Use WarpBuild runners for CI workflows

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   sdk-test-docker:
     if: github.repository_owner == 'restatedev'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-4x
     name: "Create test-services Docker Image"
     
     steps:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -36,7 +36,7 @@ on:
 jobs:
   sdk-test-suite:
     if: github.repository_owner == 'restatedev'
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-4x
     name: "Features integration test"
     permissions:
       contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-4x
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Migrate test, integration, and docker workflows from `ubuntu-latest` to `warp-ubuntu-latest-x64-4x`
- CLA workflow is left on GitHub-hosted runners