### PR TITLE
Refactor connection handling in ExecuteInvocation and IO helpers #132 

### DIFF
--- a/internal/restatecontext/execute_invocation.go
+++ b/internal/restatecontext/execute_invocation.go
@@ -2,6 +2,7 @@ package restatecontext
 
 import (
 	"context"
+	std_errors "errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -56,12 +57,11 @@ func invoke(restateCtx *ctx, handler Handler, logger *slog.Logger) {
 			// nothing to do, just exit
 			break
 		case *statemachine.SuspensionError:
+			restateCtx.internalLogger.LogAttrs(restateCtx, slog.LevelInfo, "Suspending invocation")
 		case statemachine.SuspensionError:
 			restateCtx.internalLogger.LogAttrs(restateCtx, slog.LevelInfo, "Suspending invocation")
-			break
-		case error:
-			if typ == io.EOF {
-				// State machine finished writing output (signalled by takeOutputAndWriteOut)
+		default:
+			if err, ok := typ.(error); ok && std_errors.Is(err, io.EOF) {
 				break
 			}
 			restateCtx.internalLogger.LogAttrs(restateCtx, slog.LevelError, "Invocation panicked, returning error to Restate", slog.Any("err", typ))
@@ -69,8 +69,6 @@ func invoke(restateCtx *ctx, handler Handler, logger *slog.Logger) {
 			if err := restateCtx.stateMachine.NotifyError(restateCtx, fmt.Sprint(typ), string(debug.Stack())); err != nil {
 				restateCtx.internalLogger.WarnContext(restateCtx, "Error when notifying error to state restateContext", log.Error(err))
 			}
-
-			break
 		}
 
 		// Consume remaining state machine output
@@ -85,6 +83,7 @@ func invoke(restateCtx *ctx, handler Handler, logger *slog.Logger) {
 		//
 		// readInputLoop closes readChan on EOF; draining it here unblocks the goroutine
 		// so it can read to natural EOF. A timeout guards against a misbehaving runtime.
+		timeout := time.After(inputDrainTimeout)
 	drainLoop:
 		for {
 			select {
@@ -92,7 +91,7 @@ func invoke(restateCtx *ctx, handler Handler, logger *slog.Logger) {
 				if !ok {
 					break drainLoop
 				}
-			case <-time.After(inputDrainTimeout):
+			case <-timeout:
 				break drainLoop
 			}
 		}

--- a/internal/restatecontext/execute_invocation.go
+++ b/internal/restatecontext/execute_invocation.go
@@ -15,6 +15,10 @@ import (
 	"github.com/restatedev/sdk-go/internal/statemachine"
 )
 
+// inputDrainTimeout is the maximum time to wait for the request stream to reach EOF
+// after the handler finishes, before forcefully closing the connection.
+const inputDrainTimeout = 5 * time.Second
+
 func ExecuteInvocation(ctx context.Context, logger *slog.Logger, stateMachine *statemachine.StateMachine, conn io.ReadWriteCloser, handler Handler, dropReplayLogs bool, logHandler slog.Handler, attemptHeaders map[string][]string) error {
 	// Let's read the input entry
 	invocationInput, err := stateMachine.SysInput(ctx)
@@ -23,7 +27,9 @@ func ExecuteInvocation(ctx context.Context, logger *slog.Logger, stateMachine *s
 		if err = consumeOutput(ctx, stateMachine, conn); err != nil {
 			logger.WarnContext(ctx, "Error when consuming output", log.Error(err))
 		}
-		conn.Close()
+		if err := conn.Close(); err != nil {
+			logger.WarnContext(ctx, "Error when closing connection", log.Error(err))
+		}
 		return err
 	}
 
@@ -53,8 +59,8 @@ func invoke(restateCtx *ctx, handler Handler, logger *slog.Logger) {
 		case statemachine.SuspensionError:
 			restateCtx.internalLogger.LogAttrs(restateCtx, slog.LevelInfo, "Suspending invocation")
 			break
-		default:
-			if err, ok := typ.(error); ok && err == io.EOF {
+		case error:
+			if typ == io.EOF {
 				// State machine finished writing output (signalled by takeOutputAndWriteOut)
 				break
 			}
@@ -79,8 +85,6 @@ func invoke(restateCtx *ctx, handler Handler, logger *slog.Logger) {
 		//
 		// readInputLoop closes readChan on EOF; draining it here unblocks the goroutine
 		// so it can read to natural EOF. A timeout guards against a misbehaving runtime.
-		drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer drainCancel()
 	drainLoop:
 		for {
 			select {
@@ -88,19 +92,16 @@ func invoke(restateCtx *ctx, handler Handler, logger *slog.Logger) {
 				if !ok {
 					break drainLoop
 				}
-			case <-drainCtx.Done():
+			case <-time.After(inputDrainTimeout):
 				break drainLoop
 			}
 		}
 
 		// Close the connection after draining (or after timeout).
+		// conn.Close cancels the context, which unblocks readInputLoop if it is still
+		// blocked on a send to readChan (via the ctx.Done() select case in readInputLoop).
 		if err := restateCtx.conn.Close(); err != nil {
 			restateCtx.internalLogger.WarnContext(restateCtx, "Error when closing connection", log.Error(err))
-		}
-
-		// If we timed out, readInputLoop may still be blocked trying to send on readChan.
-		// Drain any remaining items so the goroutine can exit.
-		for range restateCtx.readChan {
 		}
 	}()
 

--- a/internal/restatecontext/execute_invocation.go
+++ b/internal/restatecontext/execute_invocation.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"runtime/debug"
+	"time"
 
 	"github.com/restatedev/sdk-go/encoding"
 	"github.com/restatedev/sdk-go/internal/errors"
@@ -21,8 +22,8 @@ func ExecuteInvocation(ctx context.Context, logger *slog.Logger, stateMachine *s
 		logger.WarnContext(ctx, "Error when reading invocation input", log.Error(err))
 		if err = consumeOutput(ctx, stateMachine, conn); err != nil {
 			logger.WarnContext(ctx, "Error when consuming output", log.Error(err))
-			return err
 		}
+		conn.Close()
 		return err
 	}
 
@@ -53,6 +54,10 @@ func invoke(restateCtx *ctx, handler Handler, logger *slog.Logger) {
 			restateCtx.internalLogger.LogAttrs(restateCtx, slog.LevelInfo, "Suspending invocation")
 			break
 		default:
+			if err, ok := typ.(error); ok && err == io.EOF {
+				// State machine finished writing output (signalled by takeOutputAndWriteOut)
+				break
+			}
 			restateCtx.internalLogger.LogAttrs(restateCtx, slog.LevelError, "Invocation panicked, returning error to Restate", slog.Any("err", typ))
 
 			if err := restateCtx.stateMachine.NotifyError(restateCtx, fmt.Sprint(typ), string(debug.Stack())); err != nil {
@@ -62,9 +67,40 @@ func invoke(restateCtx *ctx, handler Handler, logger *slog.Logger) {
 			break
 		}
 
-		// Consume all the state restateContext output as last step
+		// Consume remaining state machine output
 		if err := consumeOutput(restateCtx, restateCtx.stateMachine, restateCtx.conn); err != nil {
 			restateCtx.internalLogger.WarnContext(restateCtx, "Error when consuming output", log.Error(err))
+		}
+
+		// Drain the input stream to EOF before closing the connection.
+		// Without this, Go's HTTP/2 server sends RST_STREAM when the handler returns
+		// before the request body is fully consumed, which the Restate runtime
+		// interprets as an abort.
+		//
+		// readInputLoop closes readChan on EOF; draining it here unblocks the goroutine
+		// so it can read to natural EOF. A timeout guards against a misbehaving runtime.
+		drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer drainCancel()
+	drainLoop:
+		for {
+			select {
+			case _, ok := <-restateCtx.readChan:
+				if !ok {
+					break drainLoop
+				}
+			case <-drainCtx.Done():
+				break drainLoop
+			}
+		}
+
+		// Close the connection after draining (or after timeout).
+		if err := restateCtx.conn.Close(); err != nil {
+			restateCtx.internalLogger.WarnContext(restateCtx, "Error when closing connection", log.Error(err))
+		}
+
+		// If we timed out, readInputLoop may still be blocked trying to send on readChan.
+		// Drain any remaining items so the goroutine can exit.
+		for range restateCtx.readChan {
 		}
 	}()
 

--- a/internal/restatecontext/io_helpers.go
+++ b/internal/restatecontext/io_helpers.go
@@ -2,11 +2,12 @@ package restatecontext
 
 import (
 	"context"
-	"github.com/restatedev/sdk-go/internal/log"
-	"github.com/restatedev/sdk-go/internal/statemachine"
 	"io"
 	"log/slog"
 	"sync"
+
+	"github.com/restatedev/sdk-go/internal/log"
+	"github.com/restatedev/sdk-go/internal/statemachine"
 )
 
 var BufPool sync.Pool

--- a/internal/restatecontext/io_helpers.go
+++ b/internal/restatecontext/io_helpers.go
@@ -50,8 +50,8 @@ type readResult struct {
 }
 
 func (restateCtx *ctx) readInputLoop(logger *slog.Logger) {
+	defer close(restateCtx.readChan)
 	for {
-		// Acquire buf
 		tempBuf := BufPool.Get().([]byte)
 		read, err := restateCtx.conn.Read(tempBuf)
 		if err != nil {
@@ -59,13 +59,14 @@ func (restateCtx *ctx) readInputLoop(logger *slog.Logger) {
 			if err != io.EOF {
 				logger.WarnContext(restateCtx, "Unexpected when reading input", log.Error(err))
 			}
-			close(restateCtx.readChan)
 			return
 		}
 		if read != 0 {
-			restateCtx.readChan <- readResult{
-				nRead: read,
-				buf:   tempBuf,
+			select {
+			case restateCtx.readChan <- readResult{nRead: read, buf: tempBuf}:
+			case <-restateCtx.Done():
+				BufPool.Put(tempBuf)
+				return
 			}
 		}
 	}

--- a/internal/restatecontext/io_helpers.go
+++ b/internal/restatecontext/io_helpers.go
@@ -17,10 +17,10 @@ func init() {
 	}}
 }
 
-func takeOutputAndWriteOut(ctx context.Context, machine *statemachine.StateMachine, conn io.WriteCloser) error {
+func takeOutputAndWriteOut(ctx context.Context, machine *statemachine.StateMachine, conn io.Writer) error {
 	buffer, err := machine.TakeOutput(ctx)
 	if err == io.EOF {
-		return conn.Close()
+		return io.EOF
 	} else if err != nil {
 		return err
 	}
@@ -28,11 +28,11 @@ func takeOutputAndWriteOut(ctx context.Context, machine *statemachine.StateMachi
 	return err
 }
 
-func consumeOutput(ctx context.Context, machine *statemachine.StateMachine, conn io.WriteCloser) error {
+func consumeOutput(ctx context.Context, machine *statemachine.StateMachine, conn io.Writer) error {
 	for {
 		buffer, err := machine.TakeOutput(ctx)
 		if err == io.EOF {
-			return conn.Close()
+			return nil
 		} else if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Introduced a timeout mechanism for draining the input stream to EOF before closing the connection, preventing premature RST_STREAM errors in HTTP/2.
- Updated `takeOutputAndWriteOut` and `consumeOutput` functions to return nil instead of closing the connection on EOF, allowing for better control over connection management.
- Enhanced error logging for connection closure failures.