### PR TITLE
Move stream draining to request handler

### DIFF
--- a/internal/restatecontext/async_results.go
+++ b/internal/restatecontext/async_results.go
@@ -79,7 +79,7 @@ func (a *asyncResult) pollProgressAndLoadValue() statemachine.Value {
 
 func (restateCtx *ctx) pollProgress(handles []uint32) bool {
 	// Pump output once
-	if err := takeOutputAndWriteOut(restateCtx, restateCtx.stateMachine, restateCtx.conn); err != nil {
+	if err := takeOutputAndWriteOut(restateCtx, restateCtx.stateMachine, restateCtx.stream); err != nil {
 		panic(err)
 	}
 
@@ -114,7 +114,7 @@ func (restateCtx *ctx) pollProgress(handles []uint32) bool {
 				}
 
 				// Pump output once. This is needed for the run completion to be effectively written
-				if err := takeOutputAndWriteOut(restateCtx, restateCtx.stateMachine, restateCtx.conn); err != nil {
+				if err := takeOutputAndWriteOut(restateCtx, restateCtx.stateMachine, restateCtx.stream); err != nil {
 					panic(err)
 				}
 				break
@@ -124,7 +124,7 @@ func (restateCtx *ctx) pollProgress(handles []uint32) bool {
 		}
 		if _, ok := progressResult.(statemachine.DoProgressCancelSignalReceived); ok {
 			// Pump output once. This is needed for cancel commands to be effectively written
-			if err := takeOutputAndWriteOut(restateCtx, restateCtx.stateMachine, restateCtx.conn); err != nil {
+			if err := takeOutputAndWriteOut(restateCtx, restateCtx.stateMachine, restateCtx.stream); err != nil {
 				panic(err)
 			}
 

--- a/internal/restatecontext/ctx.go
+++ b/internal/restatecontext/ctx.go
@@ -70,7 +70,11 @@ type Context interface {
 type ctx struct {
 	context.Context
 
-	conn     io.ReadWriteCloser
+	// stream does not implement `Close`
+	// because the handler makes sure to drain
+	// and close the request stream at the end
+	// before the requestHandler returns.
+	stream   io.ReadWriter
 	readChan chan readResult
 
 	stateMachine *statemachine.StateMachine
@@ -95,7 +99,7 @@ type ctx struct {
 
 var _ Context = (*ctx)(nil)
 
-func newContext(inner context.Context, machine *statemachine.StateMachine, invocationInput *pbinternal.VmSysInputReturn_Input, conn io.ReadWriteCloser, attemptHeaders map[string][]string, dropReplayLogs bool, logHandler slog.Handler) *ctx {
+func newContext(inner context.Context, machine *statemachine.StateMachine, invocationInput *pbinternal.VmSysInputReturn_Input, stream io.ReadWriter, attemptHeaders map[string][]string, dropReplayLogs bool, logHandler slog.Handler) *ctx {
 	request := Request{
 		ID:             invocationInput.GetInvocationId(),
 		Headers:        make(map[string]string),
@@ -122,7 +126,7 @@ func newContext(inner context.Context, machine *statemachine.StateMachine, invoc
 	// progress towards producing an output message
 	ctx := &ctx{
 		Context:               inner,
-		conn:                  conn,
+		stream:                stream,
 		readChan:              make(chan readResult),
 		stateMachine:          machine,
 		key:                   invocationInput.GetKey(),

--- a/internal/restatecontext/execute_invocation.go
+++ b/internal/restatecontext/execute_invocation.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"runtime/debug"
-	"time"
 
 	"github.com/restatedev/sdk-go/encoding"
 	"github.com/restatedev/sdk-go/internal/errors"
@@ -15,26 +14,20 @@ import (
 	"github.com/restatedev/sdk-go/internal/statemachine"
 )
 
-// inputDrainTimeout is the maximum time to wait for the request stream to reach EOF
-// after the handler finishes, before forcefully closing the connection.
-const inputDrainTimeout = 5 * time.Second
-
-func ExecuteInvocation(ctx context.Context, logger *slog.Logger, stateMachine *statemachine.StateMachine, conn io.ReadWriteCloser, handler Handler, dropReplayLogs bool, logHandler slog.Handler, attemptHeaders map[string][]string) error {
+func ExecuteInvocation(ctx context.Context, logger *slog.Logger, stateMachine *statemachine.StateMachine, stream io.ReadWriter, handler Handler, dropReplayLogs bool, logHandler slog.Handler, attemptHeaders map[string][]string) error {
 	// Let's read the input entry
 	invocationInput, err := stateMachine.SysInput(ctx)
 	if err != nil {
 		logger.WarnContext(ctx, "Error when reading invocation input", log.Error(err))
-		if err = takeOutputAndWriteOut(ctx, stateMachine, conn); err != nil {
+		if err = takeOutputAndWriteOut(ctx, stateMachine, stream); err != nil {
 			logger.WarnContext(ctx, "Error when consuming output", log.Error(err))
 		}
-		if err := conn.Close(); err != nil {
-			logger.WarnContext(ctx, "Error when closing connection", log.Error(err))
-		}
+
 		return err
 	}
 
 	// Instantiate the restate context
-	restateCtx := newContext(ctx, stateMachine, invocationInput, conn, attemptHeaders, dropReplayLogs, logHandler)
+	restateCtx := newContext(ctx, stateMachine, invocationInput, stream, attemptHeaders, dropReplayLogs, logHandler)
 
 	// Invoke the handler
 	invoke(restateCtx, handler, logger)
@@ -68,35 +61,8 @@ func invoke(restateCtx *ctx, handler Handler, logger *slog.Logger) {
 		}
 
 		// Consume remaining state machine output
-		if err := takeOutputAndWriteOut(restateCtx, restateCtx.stateMachine, restateCtx.conn); err != nil {
+		if err := takeOutputAndWriteOut(restateCtx, restateCtx.stateMachine, restateCtx.stream); err != nil {
 			restateCtx.internalLogger.WarnContext(restateCtx, "Error when consuming output", log.Error(err))
-		}
-
-		// Drain the input stream to EOF before closing the connection.
-		// Without this, Go's HTTP/2 server sends RST_STREAM when the handler returns
-		// before the request body is fully consumed, which the Restate runtime
-		// interprets as an abort.
-		//
-		// readInputLoop closes readChan on EOF; draining it here unblocks the goroutine
-		// so it can read to natural EOF. A timeout guards against a misbehaving runtime.
-		timeout := time.After(inputDrainTimeout)
-	drainLoop:
-		for {
-			select {
-			case _, ok := <-restateCtx.readChan:
-				if !ok {
-					break drainLoop
-				}
-			case <-timeout:
-				break drainLoop
-			}
-		}
-
-		// Close the connection after draining (or after timeout).
-		// conn.Close cancels the context, which unblocks readInputLoop if it is still
-		// blocked on a send to readChan (via the ctx.Done() select case in readInputLoop).
-		if err := restateCtx.conn.Close(); err != nil {
-			restateCtx.internalLogger.WarnContext(restateCtx, "Error when closing connection", log.Error(err))
 		}
 	}()
 

--- a/internal/restatecontext/io_helpers.go
+++ b/internal/restatecontext/io_helpers.go
@@ -34,9 +34,10 @@ type readResult struct {
 
 func (restateCtx *ctx) readInputLoop(logger *slog.Logger) {
 	defer close(restateCtx.readChan)
+
 	for {
 		tempBuf := BufPool.Get().([]byte)
-		read, err := restateCtx.conn.Read(tempBuf)
+		read, err := restateCtx.stream.Read(tempBuf)
 		if err != nil {
 			BufPool.Put(tempBuf)
 			if err != io.EOF {

--- a/server/restate.go
+++ b/server/restate.go
@@ -472,10 +472,18 @@ func (r *Restate) handleInvokeRequest(service, method string, writer http.Respon
 	request = request.WithContext(ctx)
 
 	// Create new connection. cancel will be invoked when the connection is closed.
-	conn := newConnection(writer, request, cancel)
+	stream := newStream(writer, request)
 
 	serviceMethod := fmt.Sprintf("%s/%s", service, method)
 	logger := r.systemLog.With("method", slog.StringValue(serviceMethod))
+
+	defer func() {
+		cancel()
+
+		if err := stream.Drain(); err != nil {
+			logger.WarnContext(ctx, "Failed to drain request stream", log.Error(err))
+		}
+	}()
 
 	definition, ok := r.definitions[service]
 	if !ok {
@@ -541,7 +549,7 @@ func (r *Restate) handleInvokeRequest(service, method string, writer http.Respon
 		if isReadyToExecute {
 			break
 		}
-		read, err := conn.Read(buf)
+		read, err := stream.Read(buf)
 		// from the io.Reader docs:
 		// Callers should always process the n > 0 bytes returned before considering the error err.
 		// Doing so correctly handles I/O errors that happen after reading some bytes and also both of the allowed EOF behaviors.
@@ -576,7 +584,7 @@ func (r *Restate) handleInvokeRequest(service, method string, writer http.Respon
 	restatecontext.BufPool.Put(buf)
 
 	// Run the handler
-	if err := restatecontext.ExecuteInvocation(ctx, logger, stateMachine, conn, handler, r.dropReplayLogs, logHandler, request.Header); err != nil {
+	if err := restatecontext.ExecuteInvocation(ctx, logger, stateMachine, stream, handler, r.dropReplayLogs, logHandler, request.Header); err != nil {
 		r.systemLog.LogAttrs(ctx, slog.LevelError, "Failed to handle invocation", log.Error(err))
 	}
 }

--- a/server/stream.go
+++ b/server/stream.go
@@ -2,32 +2,37 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"sync"
+	"time"
 )
 
-type connection struct {
+// inputDrainTimeout is the maximum time to wait for the request stream to reach EOF
+// after the handler finishes, before forcefully closing the connection.
+const inputDrainTimeout = 5 * time.Second
+
+type stream struct {
 	r       io.ReadCloser
 	flusher http.Flusher
 	w       http.ResponseWriter
-	cancel  func()
 
 	wLock sync.Mutex
 	rLock sync.Mutex
 }
 
-func newConnection(w http.ResponseWriter, r *http.Request, cancel func()) *connection {
+func newStream(w http.ResponseWriter, r *http.Request) *stream {
 	flusher, _ := w.(http.Flusher)
-	c := &connection{r: r.Body, flusher: flusher, w: w, cancel: cancel}
+	c := &stream{r: r.Body, flusher: flusher, w: w}
 	return c
 }
 
-func (c *connection) Write(data []byte) (int, error) {
+func (c *stream) Write(data []byte) (int, error) {
 	c.wLock.Lock()
 	defer c.wLock.Unlock()
 
-	if (data == nil) || (len(data) == 0) {
+	if len(data) == 0 {
 		return 0, nil
 	}
 	n, err := c.w.Write(data)
@@ -37,7 +42,7 @@ func (c *connection) Write(data []byte) (int, error) {
 	return n, err
 }
 
-func (c *connection) Read(data []byte) (int, error) {
+func (c *stream) Read(data []byte) (int, error) {
 	c.rLock.Lock()
 	defer c.rLock.Unlock()
 
@@ -53,9 +58,24 @@ func (c *connection) Read(data []byte) (int, error) {
 	return n, err
 }
 
-func (c *connection) Close() error {
-	c.cancel()
-	// Unblock Read()
-	c.r.Close()
+// Drains and close connection
+func (c *stream) Drain() error {
+	defer c.r.Close()
+
+	ch := make(chan error)
+	go func(errCh chan<- error) {
+		_, err := io.Copy(io.Discard, c.r)
+		errCh <- err
+	}(ch)
+
+	select {
+	case err := <-ch:
+		if err != nil && err != io.EOF {
+			return err
+		}
+	case <-time.After(inputDrainTimeout):
+		return fmt.Errorf("Timeout waiting on request draining")
+	}
+
 	return nil
 }


### PR DESCRIPTION

Summary:
This PR moved request draining to handleInvokeRequest this way
we are sure that:
- Request is always drained before returing
- Context is always cancelled when the handler is done
