### PR TITLE
Fix license check CI step: match Go version to go.mod

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21.x"
+          go-version-file: 'go.mod'
       - name: Install dependencies
         run: go get .
       - name: Vet
@@ -25,5 +25,5 @@ jobs:
         run: go test -v ./...
       - name: Check dependency licenses
         run: |
-          go install github.com/google/go-licenses@latest
+          go install github.com/google/go-licenses@v1.6.0
           go-licenses check ./... --allowed_licenses=Apache-2.0,MIT,BSD-2-Clause,BSD-3-Clause,ISC,0BSD,MPL-2.0


### PR DESCRIPTION
## Problem

The `Check dependency licenses` step added in #144 fails on `main` — but **no disallowed license was actually found**. It's a tooling/version mismatch:

- `Setup Go` pins **`go-version: "1.21.x"`**, while `go.mod` declares **`go 1.24.0`**.
- Go therefore silently downloads and swaps in the `1.24.0` toolchain.
- `go-licenses@latest` resolves to **v1.6.0** (2023), built against the old `golang.org/x/tools v0.5.0`, which can't read module info from the swapped-in toolchain's `go list` output.
- Result: it errors `Non go modules projects are no longer supported` for **every** package (even stdlib `bytes`/`fmt`) and exits 1.

Vet/Build/Test tolerate the toolchain auto-download; only `go-licenses` (with its stale x/tools) breaks on it.

## Fix

- `go-version: "1.21.x"` → **`go-version-file: 'go.mod'`** — CI's Go now matches the module, so no toolchain swap happens, and it auto-tracks future `go.mod` bumps. (The `1.21.x` pin was already inconsistent with the required `1.24.0`; only the silent toolchain download was masking it.)
- `go-licenses@latest` → **`@v1.6.0`** — pin for reproducibility.

## Verification

With Go ≥ 1.24 (matching `go.mod`, no toolchain swap), the exact command exits **0** against `main`'s dependency set with no disallowed licenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)