### PR TITLE
Fix data race between stream Drain and concurrent Read

### DIFF
--- a/server/stream.go
+++ b/server/stream.go
@@ -62,8 +62,12 @@ func (c *stream) Read(data []byte) (int, error) {
 func (c *stream) Drain() error {
 	defer c.r.Close()
 
-	ch := make(chan error)
+	// Buffered so the drain goroutine never strands if we return on timeout below.
+	ch := make(chan error, 1)
 	go func(errCh chan<- error) {
+		// Take rLock so draining does not race with an in-flight Read on c.r.
+		c.rLock.Lock()
+		defer c.rLock.Unlock()
 		_, err := io.Copy(io.Discard, c.r)
 		errCh <- err
 	}(ch)

--- a/server/stream_test.go
+++ b/server/stream_test.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+// TestDrainReadRace exercises Drain concurrently with Read against a shared
+// underlying reader. Both paths ultimately call the reader's Read, so unless
+// Drain takes rLock the two run without synchronization. Run with -race:
+// before the fix this reports a data race on the shared reader's internal
+// state, after the fix rLock serializes the two paths and it passes.
+func TestDrainReadRace(t *testing.T) {
+	body := bytes.Repeat([]byte("x"), 1<<20)
+	c := &stream{r: io.NopCloser(bytes.NewReader(body))}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 512)
+		for {
+			if _, err := c.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	if err := c.Drain(); err != nil {
+		t.Fatalf("Drain returned error: %v", err)
+	}
+	<-done
+}


### PR DESCRIPTION
`stream.Read` takes `rLock` before reading `c.r`, but `Drain` ran
`io.Copy(io.Discard, c.r)` in a goroutine without the lock, racing with an
in-flight read on the same reader (#156).

This takes `rLock` in the drain goroutine so the two paths are serialized, and
makes the result channel buffered so the goroutine does not strand if `Drain`
returns on the timeout path.

Validation (local):
- Added `server/stream_test.go` reproducing the race. `go test -race ./server/`
  reports the race on the current code and passes with the fix (verified by
  reverting stream.go).
- `go vet ./...`, `go build ./...`, `go test -short ./...` all pass.

Note: CI runs `go test -short` (no `-race`), so this regression only shows under
`-race`. Running `go test -race ./server/` catches it.

Closes #156
